### PR TITLE
Migrate Python core objects/specs into Rust and release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-07
+
+### Changed
+- Bump crate version to 0.3.0.
+- Migrate Python-aligned core shared objects into Rust.
+
 ## [0.2.4] - 2025-03-12
 
 ### Fixed
@@ -78,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable resource limits
 - Optimized cryptographic operations
 
-[Unreleased]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.2...v0.2.4
 [0.2.2]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaincraft"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaincraft"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Chaincraft Contributors"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add Chaincraft Rust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = "0.2.4"
+chaincraft = "0.3.0"
 ```
 
 ### Basic Example
@@ -195,7 +195,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = { version = "0.2.4", features = ["persistent", "indexing"] }
+chaincraft = { version = "0.3.0", features = ["persistent", "indexing"] }
 ```
 
 ## Development

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,0 +1,104 @@
+# Chaincraft Rust Protocol Specification v1
+
+This document describes how to implement a protocol in `chaincraft-rust`.
+
+You implement protocol logic; Chaincraft handles networking, gossip, storage,
+peer management, and runtime concurrency.
+
+## Core Abstractions
+
+### SharedMessage
+
+`SharedMessage` is the transport envelope for JSON data exchanged between nodes.
+
+```rust
+use chaincraft::shared::{MessageType, SharedMessage};
+
+let msg = SharedMessage::new(
+    MessageType::Custom("MY_VOTE".to_string()),
+    serde_json::json!({"value": 42}),
+);
+```
+
+### ApplicationObject
+
+Protocols are implemented as `ApplicationObject` objects.
+
+Key methods:
+
+- `is_valid(&self, message)` for validation
+- `add_message(&mut self, message)` for state transition
+- `is_merkleized()` and digest methods for sync strategy
+- `gossip_messages()` / `get_messages_since_digest()` for sync deltas
+
+### ChaincraftNode
+
+`ChaincraftNode` is the runtime:
+
+- receives messages
+- stores and broadcasts accepted messages
+- dispatches each message to registered application objects
+
+## Message Flow
+
+For incoming or locally-created gossip messages:
+
+1. Build or parse `SharedMessage`.
+2. Pass through registered application objects.
+3. Store in node storage.
+4. Broadcast to peers.
+
+Each object should keep protocol routing inside `add_message` and call private
+helpers for concrete state transitions.
+
+## Merkelized vs Non-Merkelized Objects
+
+Use merkelized objects when digest-based synchronization matters (chains, DAGs,
+state ledgers).
+
+Use non-merkelized objects for eventually-consistent, gossip-only state where
+digest state proofs are unnecessary (cache/mempool-like queues).
+
+## Rust Core Objects
+
+The Rust crate exposes Python-aligned core objects:
+
+- Merkelized:
+  - `MerkelizedObject`
+  - `UTXOLedger`
+  - `BalanceLedger`
+  - `Blockchain`
+  - `DAGObject`
+  - `TransactionChain`
+- Non-merkelized:
+  - `NonMerkelizedObject`
+  - `CacheObject`
+  - `Mempool`
+  - `DocumentCache`
+
+Compatibility aliases:
+
+- `MerkleizedObject` -> `MerkelizedObject`
+- `NativeSharedObject` -> `CoreSharedObject`
+
+## Object Registration
+
+```rust
+use chaincraft::{
+    network::PeerId,
+    storage::MemoryStorage,
+    BalanceLedger, ChaincraftNode,
+};
+use std::sync::Arc;
+
+let storage = Arc::new(MemoryStorage::new());
+let mut node = ChaincraftNode::new(PeerId::new(), storage);
+node.add_shared_object(Box::new(BalanceLedger::new())).await?;
+```
+
+## Guidance
+
+- Keep validation logic strict in `is_valid`.
+- Keep state mutation in `add_message`.
+- Use digest methods only for merkelized objects.
+- Avoid direct network/thread management in protocol objects.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,67 +1,177 @@
 # Chaincraft Rust Protocol Specification v1
 
-This document describes how to implement a protocol in `chaincraft-rust`.
+This document describes how to implement protocols with `chaincraft-rust`.
 
-You implement protocol logic; Chaincraft handles networking, gossip, storage,
-peer management, and runtime concurrency.
+You write protocol/application logic; Chaincraft runtime handles UDP networking,
+message propagation, deduplication, storage, peer tracking, and background tasks.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                        ChaincraftNode                        │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ start_networking()                                    │  │
+│  │ - UDP receive loop                                    │  │
+│  │ - gossip rebroadcast loop                             │  │
+│  │ - digest sync control path                            │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                                                              │
+│  app_objects: ApplicationObjectRegistry                      │
+│     └── process_message(msg):                                │
+│         - object.is_valid(msg)                               │
+│         - if valid => object.add_message(msg)                │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
 
 ## Core Abstractions
 
-### SharedMessage
+### `SharedMessage`
 
-`SharedMessage` is the transport envelope for JSON data exchanged between nodes.
+Transport envelope exchanged between nodes as JSON.
+
+Key fields:
+
+- `id: SharedObjectId`
+- `message_type: MessageType`
+- `target_id: Option<SharedObjectId>`
+- `data: serde_json::Value`
+- `timestamp`
+- `signature: Option<Vec<u8>>`
+- `hash`
+
+Create messages with:
 
 ```rust
 use chaincraft::shared::{MessageType, SharedMessage};
 
 let msg = SharedMessage::new(
     MessageType::Custom("MY_VOTE".to_string()),
-    serde_json::json!({"value": 42}),
+    serde_json::json!({"round": 7, "vote": "yes"}),
 );
 ```
 
-### ApplicationObject
+### `ApplicationObject`
 
-Protocols are implemented as `ApplicationObject` objects.
+Protocols are implemented as `ApplicationObject` implementations.
 
-Key methods:
+Main methods:
 
-- `is_valid(&self, message)` for validation
-- `add_message(&mut self, message)` for state transition
-- `is_merkleized()` and digest methods for sync strategy
-- `gossip_messages()` / `get_messages_since_digest()` for sync deltas
+- `is_valid(&self, message) -> Result<bool>`
+- `add_message(&mut self, message) -> Result<()>`
+- `is_merkleized() -> bool`
+- digest methods (`get_latest_digest`, `has_digest`, `is_valid_digest`, `add_digest`)
+- sync methods (`gossip_messages`, `get_messages_since_digest`)
+- lifecycle/state (`get_state`, `reset`)
 
-### ChaincraftNode
+### `ChaincraftNode`
 
-`ChaincraftNode` is the runtime:
+Runtime entrypoint for networking and protocol dispatch.
 
-- receives messages
-- stores and broadcasts accepted messages
-- dispatches each message to registered application objects
+Important methods:
 
-## Message Flow
+- `start()` / `close()`
+- `connect_to_peer("host:port")`
+- `add_shared_object(Box<dyn ApplicationObject>)`
+- `create_shared_message_with_data(serde_json::Value)`
+- `create_shared_message(String)` (compatibility helper)
 
-For incoming or locally-created gossip messages:
+## Message Types and P2P Control Messages
 
-1. Build or parse `SharedMessage`.
-2. Pass through registered application objects.
-3. Store in node storage.
-4. Broadcast to peers.
+`MessageType` supports both application messages and protocol control plane messages.
 
-Each object should keep protocol routing inside `add_message` and call private
-helpers for concrete state transitions.
+Built-in control types include:
+
+- `PEER_DISCOVERY`, `REQUEST_LOCAL_PEERS`, `LOCAL_PEERS`
+- `REQUEST_SHARED_OBJECT_UPDATE`, `SHARED_OBJECT_UPDATE`
+- `REQUEST_DIGEST`, `DIGEST_RESPONSE`
+- `REQUEST_MESSAGES_SINCE`, `MESSAGES_RESPONSE`
+- `GET`, `SET`, `DELETE`, `RESPONSE`, `NOTIFICATION`, `HEARTBEAT`, `ERROR`
+
+For protocol-specific traffic, use `MessageType::Custom("...")`.
+
+Example data payload with explicit type:
+
+```rust
+let data = serde_json::json!({
+    "type": "SLUSH_VOTE",
+    "round": 3,
+    "color": "red"
+});
+node.create_shared_message_with_data(data).await?;
+```
+
+## Message Flow (Gossip/Data Path)
+
+### Outbound (local create)
+
+`create_shared_message_with_data(data)` performs:
+
+1. Resolve `MessageType` from `data["type"]` (or default custom type).
+2. Build `SharedMessage`.
+3. Store message in node storage.
+4. Run `ApplicationObjectRegistry::process_message`.
+5. Broadcast JSON payload over UDP to known peers.
+
+### Inbound (from peer datagram)
+
+Receive loop performs:
+
+1. Parse control/digest messages first.
+2. Else parse datagram as `SharedMessage`.
+3. Deduplicate by `hash` (skip if already stored).
+4. Store in node storage.
+5. Dispatch via `process_message`.
+6. Re-broadcast to peers for propagation.
+
+## Request/Response and Sync Path
+
+Rust runtime includes a control-plane request/response path over UDP JSON:
+
+- `REQUEST_DIGEST` -> `DIGEST_RESPONSE`
+- `REQUEST_MESSAGES_SINCE` -> `MESSAGES_RESPONSE`
+
+When digests differ, peers request missing messages and apply them through the
+same `process_message` path used by normal gossip.
+
+This is the Rust equivalent of direct synchronization traffic: messages are
+point-to-point UDP exchanges but still represented in JSON and integrated with
+object-level digest methods.
+
+## Validation and Processing Semantics
+
+`ApplicationObjectRegistry::process_message` evaluates each registered object
+sequentially:
+
+1. `object.is_valid(&message)`
+2. If valid for that object, call `object.add_message(message.clone())`
+3. Continue to next object
+
+Important: processing is per-object. A rejection in one object does not prevent
+other objects from processing if they validate the same message.
 
 ## Merkelized vs Non-Merkelized Objects
 
-Use merkelized objects when digest-based synchronization matters (chains, DAGs,
-state ledgers).
+Use merkelized objects when digest-based state sync matters:
 
-Use non-merkelized objects for eventually-consistent, gossip-only state where
-digest state proofs are unnecessary (cache/mempool-like queues).
+- chains
+- DAGs
+- ledgers/state snapshots
+
+Use non-merkelized objects when gossip plus hash deduplication is enough:
+
+- mempool queues
+- transient caches
+- loosely ordered event streams
+
+For non-merkelized objects, keep digest methods simple/minimal and return empty
+sync payloads as appropriate.
 
 ## Rust Core Objects
 
-The Rust crate exposes Python-aligned core objects:
+The crate exposes Python-aligned core objects:
 
 - Merkelized:
   - `MerkelizedObject`
@@ -81,14 +191,18 @@ Compatibility aliases:
 - `MerkleizedObject` -> `MerkelizedObject`
 - `NativeSharedObject` -> `CoreSharedObject`
 
-## Object Registration
+## Implementing a Protocol
+
+### 1) Define an `ApplicationObject`
+
+- Keep structural/state checks in `is_valid`.
+- Keep mutations in `add_message`.
+- Route by `message.message_type` or `message.data["type"]` inside `add_message`.
+
+### 2) Register object(s) on a node
 
 ```rust
-use chaincraft::{
-    network::PeerId,
-    storage::MemoryStorage,
-    BalanceLedger, ChaincraftNode,
-};
+use chaincraft::{network::PeerId, storage::MemoryStorage, BalanceLedger, ChaincraftNode};
 use std::sync::Arc;
 
 let storage = Arc::new(MemoryStorage::new());
@@ -96,9 +210,35 @@ let mut node = ChaincraftNode::new(PeerId::new(), storage);
 node.add_shared_object(Box::new(BalanceLedger::new())).await?;
 ```
 
-## Guidance
+### 3) Start networking and connect peers
 
-- Keep validation logic strict in `is_valid`.
-- Keep state mutation in `add_message`.
-- Use digest methods only for merkelized objects.
-- Avoid direct network/thread management in protocol objects.
+```rust
+node.start().await?;
+node.connect_to_peer("127.0.0.1:9001").await?;
+```
+
+### 4) Publish protocol messages
+
+```rust
+node.create_shared_message_with_data(serde_json::json!({
+    "type": "MY_PROTOCOL_EVENT",
+    "payload": {"x": 42}
+})).await?;
+```
+
+## Threading and Concurrency Guidance
+
+- Do not manage sockets or manual networking in protocol objects.
+- Do not create parallel protocol runtimes for message handling.
+- Keep object logic deterministic and idempotent where possible.
+- If external tasks touch shared protocol state, protect internal invariants.
+
+## What Protocol Authors Should Not Reimplement
+
+- UDP gossip fanout
+- message hash deduplication
+- peer discovery bookkeeping
+- digest-sync transport exchange
+- node lifecycle orchestration
+
+Use the provided node/runtime APIs and focus on protocol-specific state machines.

--- a/SPECS.md
+++ b/SPECS.md
@@ -8,22 +8,28 @@ message propagation, deduplication, storage, peer tracking, and background tasks
 ## Architecture Overview
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│                        ChaincraftNode                        │
-│                                                              │
-│  ┌────────────────────────────────────────────────────────┐  │
-│  │ start_networking()                                    │  │
-│  │ - UDP receive loop                                    │  │
-│  │ - gossip rebroadcast loop                             │  │
-│  │ - digest sync control path                            │  │
-│  └────────────────────────────────────────────────────────┘  │
-│                                                              │
-│  app_objects: ApplicationObjectRegistry                      │
-│     └── process_message(msg):                                │
-│         - object.is_valid(msg)                               │
-│         - if valid => object.add_message(msg)                │
-│                                                              │
-└──────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                            ChaincraftNode                            │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │ start_networking()                                             │  │
+│  │ - UDP receive loop                                             │  │
+│  │ - gossip rebroadcast loop                                      │  │
+│  │ - direct control/P2P path (non-gossip sync and requests)       │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                      │
+│  Incoming UDP datagram                                               │
+│   ├── SharedMessage gossip path                                      │
+│   │    ├── dedupe by hash + store                                    │
+│   │    ├── app_objects.process_message(msg)                          │
+│   │    │    ├── object.is_valid(msg)                                 │
+│   │    │    └── if valid => object.add_message(msg)                  │
+│   │    └── rebroadcast to peers                                      │
+│   │                                                                  │
+│   └── Direct control/P2P path (no gossip fanout)                     │
+│        └── REQUEST_DIGEST / REQUEST_MESSAGES_SINCE / responses       │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Core Abstractions

--- a/examples/shared_objects_example.rs
+++ b/examples/shared_objects_example.rs
@@ -11,11 +11,8 @@
 //! Run with: `cargo run --example shared_objects_example`
 
 use chaincraft::{
-    error::Result,
-    network::PeerId,
-    shared_object::{ApplicationObject, SimpleSharedNumber},
-    storage::MemoryStorage,
-    ChaincraftNode,
+    error::Result, network::PeerId, shared_object::ApplicationObject, storage::MemoryStorage,
+    BalanceLedger, ChaincraftNode,
 };
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
@@ -29,8 +26,8 @@ async fn create_network(num_nodes: usize) -> Result<Vec<ChaincraftNode>> {
         let storage = Arc::new(MemoryStorage::new());
         let mut node = ChaincraftNode::new(id, storage);
 
-        let shared_number: Box<dyn ApplicationObject> = Box::new(SimpleSharedNumber::new());
-        node.add_shared_object(shared_number).await?;
+        let ledger: Box<dyn ApplicationObject> = Box::new(BalanceLedger::new());
+        node.add_shared_object(ledger).await?;
         node.start().await?;
         nodes.push(node);
     }
@@ -85,12 +82,16 @@ async fn main() -> Result<()> {
 
     for i in 0..3 {
         let node_idx = i % nodes.len();
-        let value = (i + 1) as i64;
-        let data = serde_json::json!(value);
+        let value = (i + 1) as f64;
+        let data = serde_json::json!({
+            "action": "credit",
+            "account": format!("user-{node_idx}"),
+            "amount": value
+        });
         nodes[node_idx]
             .create_shared_message_with_data(data)
             .await?;
-        println!("Node {node_idx} created shared object (value={value})");
+        println!("Node {node_idx} credited user-{node_idx} with {value}");
         sleep(Duration::from_millis(500)).await;
     }
 

--- a/src/core_objects.rs
+++ b/src/core_objects.rs
@@ -1,0 +1,1459 @@
+//! Core shared objects aligned with the Python implementation.
+
+use crate::{
+    error::Result,
+    shared::{SharedMessage, SharedObjectId},
+    shared_object::ApplicationObject,
+};
+use async_trait::async_trait;
+use lru::LruCache;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::any::Any;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+type SharedKvBackend = Arc<RwLock<HashMap<String, Value>>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageMode {
+    Memory,
+    Storage,
+}
+
+impl StorageMode {
+    fn from_str(mode: &str) -> Self {
+        if mode == "storage" {
+            Self::Storage
+        } else {
+            Self::Memory
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CoreStorage {
+    persistent: bool,
+    storage_mode: StorageMode,
+    enable_memory_cache: bool,
+    memory_store: HashMap<String, Value>,
+    storage_backend: SharedKvBackend,
+    memory_cache: LruCache<String, Value>,
+}
+
+impl std::fmt::Debug for CoreStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CoreStorage")
+            .field("persistent", &self.persistent)
+            .field("storage_mode", &self.storage_mode)
+            .field("enable_memory_cache", &self.enable_memory_cache)
+            .finish()
+    }
+}
+
+impl CoreStorage {
+    fn new(
+        persistent: bool,
+        storage_mode: StorageMode,
+        storage_backend: Option<SharedKvBackend>,
+        enable_memory_cache: bool,
+        memory_cache_size: usize,
+    ) -> Self {
+        let cache_size = memory_cache_size.max(1);
+        let non_zero = NonZeroUsize::new(cache_size).expect("cache size must be non-zero");
+        Self {
+            persistent,
+            storage_mode,
+            enable_memory_cache,
+            memory_store: HashMap::new(),
+            storage_backend: storage_backend
+                .unwrap_or_else(|| Arc::new(RwLock::new(HashMap::new()))),
+            memory_cache: LruCache::new(non_zero),
+        }
+    }
+
+    async fn read(&mut self, key: &str) -> Option<Value> {
+        if self.enable_memory_cache {
+            if let Some(value) = self.memory_cache.get(key) {
+                return Some(value.clone());
+            }
+        }
+        let value = match self.storage_mode {
+            StorageMode::Memory => self.memory_store.get(key).cloned(),
+            StorageMode::Storage => {
+                let backend = self.storage_backend.read().await;
+                backend.get(key).cloned()
+            },
+        };
+        if self.enable_memory_cache {
+            if let Some(v) = value.clone() {
+                self.memory_cache.put(key.to_string(), v);
+            }
+        }
+        value
+    }
+
+    async fn write(&mut self, key: &str, value: Value) {
+        match self.storage_mode {
+            StorageMode::Memory => {
+                self.memory_store.insert(key.to_string(), value.clone());
+            },
+            StorageMode::Storage => {
+                let mut backend = self.storage_backend.write().await;
+                backend.insert(key.to_string(), value.clone());
+            },
+        }
+        if self.enable_memory_cache {
+            self.memory_cache.put(key.to_string(), value);
+        }
+    }
+
+    async fn delete(&mut self, key: &str) {
+        match self.storage_mode {
+            StorageMode::Memory => {
+                self.memory_store.remove(key);
+            },
+            StorageMode::Storage => {
+                let mut backend = self.storage_backend.write().await;
+                backend.remove(key);
+            },
+        }
+        if self.enable_memory_cache {
+            self.memory_cache.pop(key);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MerkelizedState {
+    messages: Vec<SharedMessage>,
+    digests: Vec<String>,
+    digest_index: HashMap<String, usize>,
+    parents_by_digest: HashMap<String, Vec<String>>,
+    children_by_digest: HashMap<String, HashSet<String>>,
+    head_digests: BTreeSet<String>,
+}
+
+impl MerkelizedState {
+    fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+            digests: Vec::new(),
+            digest_index: HashMap::new(),
+            parents_by_digest: HashMap::new(),
+            children_by_digest: HashMap::new(),
+            head_digests: BTreeSet::new(),
+        }
+    }
+
+    fn latest_digest(&self) -> String {
+        self.digests.last().cloned().unwrap_or_default()
+    }
+
+    fn contains_digest(&self, digest: &str) -> bool {
+        self.digest_index.contains_key(digest)
+    }
+
+    fn head_digest_list(&self) -> Vec<String> {
+        self.head_digests.iter().cloned().collect()
+    }
+
+    async fn record_message(
+        &mut self,
+        storage: &mut CoreStorage,
+        message: SharedMessage,
+        digest: String,
+        parent_digests: Vec<String>,
+    ) {
+        self.messages.push(message.clone());
+        self.digest_index.insert(digest.clone(), self.digests.len());
+        self.digests.push(digest.clone());
+        self.parents_by_digest
+            .insert(digest.clone(), parent_digests.clone());
+
+        for parent in &parent_digests {
+            self.children_by_digest
+                .entry(parent.clone())
+                .or_default()
+                .insert(digest.clone());
+            self.head_digests.remove(parent);
+        }
+        self.children_by_digest.entry(digest.clone()).or_default();
+        self.head_digests.insert(digest.clone());
+        storage.write(&digest, message.data).await;
+    }
+
+    fn messages_since_digest(&self, digest: &str) -> Vec<SharedMessage> {
+        if self.messages.is_empty() {
+            return vec![];
+        }
+        if digest.is_empty() {
+            return self.messages.clone();
+        }
+        let Some(idx) = self.digest_index.get(digest) else {
+            return vec![];
+        };
+        self.messages[(*idx + 1)..].to_vec()
+    }
+}
+
+fn canonical_json(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sorted = std::collections::BTreeMap::new();
+            for (k, v) in map {
+                sorted.insert(k.clone(), canonical_json(v));
+            }
+            let mut out = Map::new();
+            for (k, v) in sorted {
+                out.insert(k, v);
+            }
+            Value::Object(out)
+        },
+        Value::Array(arr) => Value::Array(arr.iter().map(canonical_json).collect()),
+        _ => value.clone(),
+    }
+}
+
+fn compute_digest_value(value: &Value) -> String {
+    let canonical = canonical_json(value);
+    let payload = serde_json::to_string(&canonical).unwrap_or_else(|_| "null".to_string());
+    let mut hasher = Sha256::new();
+    hasher.update(payload.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn normalize_parent_digests_from_value(value: Option<&Value>) -> Vec<String> {
+    let mut normalized = Vec::new();
+    let mut seen = HashSet::new();
+    if let Some(Value::Array(parents)) = value {
+        for p in parents {
+            if let Some(parent) = p.as_str() {
+                if parent.is_empty() || parent == "genesis" {
+                    continue;
+                }
+                if seen.insert(parent.to_string()) {
+                    normalized.push(parent.to_string());
+                }
+            }
+        }
+    }
+    normalized
+}
+
+fn extract_parent_digests(data: &Value) -> Vec<String> {
+    let Some(obj) = data.as_object() else {
+        return vec![];
+    };
+    if obj.contains_key("parents") {
+        return normalize_parent_digests_from_value(obj.get("parents"));
+    }
+    if let Some(prev) = obj.get("previous_digest").and_then(|v| v.as_str()) {
+        return normalize_parent_digests_from_value(Some(&Value::Array(vec![Value::String(
+            prev.to_string(),
+        )])));
+    }
+    vec![]
+}
+
+#[derive(Debug, Clone)]
+pub struct CoreSharedObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+}
+
+impl CoreSharedObject {
+    pub fn new(
+        persistent: bool,
+        storage_mode: &str,
+        storage_backend: Option<SharedKvBackend>,
+        enable_memory_cache: bool,
+        memory_cache_size: usize,
+    ) -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(
+                persistent,
+                StorageMode::from_str(storage_mode),
+                storage_backend,
+                enable_memory_cache,
+                memory_cache_size,
+            ),
+        }
+    }
+
+    pub fn compute_digest(data: &Value) -> String {
+        compute_digest_value(data)
+    }
+}
+
+impl Default for CoreSharedObject {
+    fn default() -> Self {
+        Self::new(false, "memory", None, true, 1024)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NonMerkelizedObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+}
+
+impl NonMerkelizedObject {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+        }
+    }
+}
+
+impl Default for NonMerkelizedObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for NonMerkelizedObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "NonMerkelizedObject"
+    }
+
+    async fn is_valid(&self, _message: &SharedMessage) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_message(&mut self, _message: SharedMessage) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"merkleized": false}))
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MerkelizedObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+}
+
+impl MerkelizedObject {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+        }
+    }
+}
+
+impl Default for MerkelizedObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for MerkelizedObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "MerkelizedObject"
+    }
+
+    async fn is_valid(&self, _message: &SharedMessage) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message, digest, parents)
+            .await;
+        Ok(())
+    }
+
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({
+            "digests": self.state.digests.len(),
+            "messages": self.state.messages.len(),
+            "head_digests": self.state.head_digest_list(),
+        }))
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+pub type MerkleizedObject = MerkelizedObject;
+pub type NativeSharedObject = CoreSharedObject;
+
+#[derive(Debug, Clone)]
+pub struct UTXOLedger {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub utxos: HashMap<String, Value>,
+}
+
+impl UTXOLedger {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            utxos: HashMap::new(),
+        }
+    }
+}
+
+impl Default for UTXOLedger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for UTXOLedger {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "UTXOLedger"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        match data.get("action").and_then(|v| v.as_str()) {
+            Some("utxo_add") => Ok(data.contains_key("utxo_id")
+                && data.contains_key("amount")
+                && data.contains_key("owner")),
+            Some("utxo_spend") => Ok(data
+                .get("utxo_id")
+                .and_then(|v| v.as_str())
+                .map(|id| self.utxos.contains_key(id))
+                .unwrap_or(false)),
+            _ => Ok(false),
+        }
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest, parents)
+            .await;
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let action = data
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if action == "utxo_add" {
+            if let Some(utxo_id) = data.get("utxo_id").and_then(|v| v.as_str()) {
+                let entry = json!({
+                    "amount": data.get("amount").cloned().unwrap_or(Value::Null),
+                    "owner": data.get("owner").cloned().unwrap_or(Value::Null),
+                    "meta": data.get("meta").cloned().unwrap_or_else(|| json!({})),
+                });
+                self.utxos.insert(utxo_id.to_string(), entry.clone());
+                self.storage.write(&format!("utxo:{utxo_id}"), entry).await;
+            }
+        } else if action == "utxo_spend" {
+            if let Some(utxo_id) = data.get("utxo_id").and_then(|v| v.as_str()) {
+                self.utxos.remove(utxo_id);
+                self.storage.delete(&format!("utxo:{utxo_id}")).await;
+            }
+        }
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"utxo_count": self.utxos.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.utxos.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BalanceLedger {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub balances: HashMap<String, f64>,
+}
+
+impl BalanceLedger {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            balances: HashMap::new(),
+        }
+    }
+}
+
+impl Default for BalanceLedger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for BalanceLedger {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "BalanceLedger"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        let action = data
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let amount = data.get("amount").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        match action {
+            "credit" => Ok(data.contains_key("account") && data.get("amount").is_some()),
+            "debit" => {
+                let Some(account) = data.get("account").and_then(|v| v.as_str()) else {
+                    return Ok(false);
+                };
+                Ok(self.balances.get(account).cloned().unwrap_or(0.0) >= amount)
+            },
+            "transfer" => {
+                let Some(src) = data.get("from").and_then(|v| v.as_str()) else {
+                    return Ok(false);
+                };
+                let has_dst = data.get("to").and_then(|v| v.as_str()).is_some();
+                Ok(has_dst && self.balances.get(src).cloned().unwrap_or(0.0) >= amount)
+            },
+            _ => Ok(false),
+        }
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest, parents)
+            .await;
+
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let action = data
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let amount = data.get("amount").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        match action {
+            "credit" => {
+                if let Some(account) = data.get("account").and_then(|v| v.as_str()) {
+                    let entry = self.balances.get(account).cloned().unwrap_or(0.0) + amount;
+                    self.balances.insert(account.to_string(), entry);
+                    self.storage
+                        .write(&format!("balance:{account}"), json!(entry))
+                        .await;
+                }
+            },
+            "debit" => {
+                if let Some(account) = data.get("account").and_then(|v| v.as_str()) {
+                    let entry = self.balances.get(account).cloned().unwrap_or(0.0) - amount;
+                    self.balances.insert(account.to_string(), entry);
+                    self.storage
+                        .write(&format!("balance:{account}"), json!(entry))
+                        .await;
+                }
+            },
+            "transfer" => {
+                if let (Some(src), Some(dst)) = (
+                    data.get("from").and_then(|v| v.as_str()),
+                    data.get("to").and_then(|v| v.as_str()),
+                ) {
+                    let src_entry = self.balances.get(src).cloned().unwrap_or(0.0) - amount;
+                    let dst_entry = self.balances.get(dst).cloned().unwrap_or(0.0) + amount;
+                    self.balances.insert(src.to_string(), src_entry);
+                    self.balances.insert(dst.to_string(), dst_entry);
+                    self.storage
+                        .write(&format!("balance:{src}"), json!(src_entry))
+                        .await;
+                    self.storage
+                        .write(&format!("balance:{dst}"), json!(dst_entry))
+                        .await;
+                }
+            },
+            _ => {},
+        }
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"balance_count": self.balances.len(), "balances": self.balances}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.balances.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Blockchain {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub blocks: Vec<Value>,
+}
+
+impl Blockchain {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            blocks: Vec::new(),
+        }
+    }
+}
+
+impl Default for Blockchain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for Blockchain {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "Blockchain"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        let prev = data
+            .get("previous_digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if self.blocks.is_empty() {
+            return Ok(prev.is_empty() || prev == "genesis");
+        }
+        let last = self
+            .blocks
+            .last()
+            .and_then(|b| b.get("digest"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        Ok(prev == last)
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest.clone(), parents)
+            .await;
+        let block = json!({
+            "digest": digest,
+            "payload": message.data
+        });
+        self.blocks.push(block.clone());
+        let key = block
+            .get("digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        self.storage.write(&format!("block:{key}"), block).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"block_count": self.blocks.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.blocks.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DAGObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub nodes: HashMap<String, Value>,
+    frontier_state_index: HashMap<String, isize>,
+    pub frontier_digest_version: u32,
+}
+
+impl DAGObject {
+    pub fn new() -> Self {
+        let mut frontier_state_index = HashMap::new();
+        frontier_state_index.insert(String::new(), -1);
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            nodes: HashMap::new(),
+            frontier_state_index,
+            frontier_digest_version: 1,
+        }
+    }
+
+    pub fn get_head_digests(&self) -> Vec<String> {
+        self.state.head_digest_list()
+    }
+
+    fn current_frontier_digest(&self) -> String {
+        let heads = self.get_head_digests();
+        if heads.is_empty() {
+            return String::new();
+        }
+        compute_digest_value(&json!({
+            "v": self.frontier_digest_version,
+            "frontier_heads": heads
+        }))
+    }
+}
+
+impl Default for DAGObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for DAGObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "DAGObject"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        let parents = normalize_parent_digests_from_value(data.get("parents"));
+        if !parents.iter().all(|p| self.nodes.contains_key(p)) {
+            return Ok(false);
+        }
+        if !parents.is_empty() {
+            let head_set: HashSet<String> = self.state.head_digest_list().into_iter().collect();
+            if !parents.iter().all(|p| head_set.contains(p)) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest.clone(), parents.clone())
+            .await;
+        let node = json!({"digest": digest, "parents": parents, "data": message.data});
+        let digest_key = node
+            .get("digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        self.nodes.insert(digest_key.clone(), node.clone());
+        self.storage.write(&format!("dag:{digest_key}"), node).await;
+        let frontier = self.current_frontier_digest();
+        self.frontier_state_index
+            .insert(frontier, (self.state.messages.len() as isize) - 1);
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.current_frontier_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest) || self.frontier_state_index.contains_key(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        self.has_digest(digest).await
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        self.get_messages_since_digest(digest.unwrap_or_default())
+            .await
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        if self.state.messages.is_empty() {
+            return Ok(vec![]);
+        }
+        if digest.is_empty() {
+            return Ok(self.state.messages.clone());
+        }
+        if let Some(idx) = self.state.digest_index.get(digest) {
+            return Ok(self.state.messages[(*idx + 1)..].to_vec());
+        }
+        if let Some(idx) = self.frontier_state_index.get(digest) {
+            let start = (*idx + 1).max(0) as usize;
+            return Ok(self.state.messages[start..].to_vec());
+        }
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"node_count": self.nodes.len(), "heads": self.get_head_digests()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.nodes.clear();
+        self.frontier_state_index.clear();
+        self.frontier_state_index.insert(String::new(), -1);
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionChain {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub transactions: Vec<Value>,
+}
+
+impl TransactionChain {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            transactions: Vec::new(),
+        }
+    }
+}
+
+impl Default for TransactionChain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for TransactionChain {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "TransactionChain"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest.clone(), parents)
+            .await;
+        let tx = json!({"tx_digest": digest, "payload": message.data});
+        self.transactions.push(tx.clone());
+        let key = tx
+            .get("tx_digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        self.storage.write(&format!("tx:{key}"), tx).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"transaction_count": self.transactions.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.transactions.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    pub cache: HashMap<String, Value>,
+}
+
+impl CacheObject {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            cache: HashMap::new(),
+        }
+    }
+}
+
+impl Default for CacheObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for CacheObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "CacheObject"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let key = data
+            .get("key")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| compute_digest_value(&message.data));
+
+        if data.get("action").and_then(|v| v.as_str()) == Some("delete") {
+            self.cache.remove(&key);
+            self.storage.delete(&key).await;
+            return Ok(());
+        }
+
+        let value = data.get("value").cloned().unwrap_or(message.data);
+        self.cache.insert(key.clone(), value.clone());
+        self.storage.write(&key, value).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"cache_size": self.cache.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.cache.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Mempool {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    pub cache: HashMap<String, Value>,
+    pub transactions: HashMap<String, Value>,
+}
+
+impl Mempool {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            cache: HashMap::new(),
+            transactions: HashMap::new(),
+        }
+    }
+}
+
+impl Default for Mempool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for Mempool {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "Mempool"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let tx = message.data.as_object().cloned().unwrap_or_default();
+        let tx_id = tx
+            .get("tx_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| compute_digest_value(&message.data));
+
+        if tx.get("action").and_then(|v| v.as_str()) == Some("remove") {
+            self.transactions.remove(&tx_id);
+            self.cache.remove(&tx_id);
+            self.storage.delete(&format!("mempool:{tx_id}")).await;
+            return Ok(());
+        }
+        let as_value = Value::Object(tx);
+        self.transactions.insert(tx_id.clone(), as_value.clone());
+        self.cache.insert(tx_id.clone(), as_value.clone());
+        self.storage
+            .write(&format!("mempool:{tx_id}"), as_value)
+            .await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"tx_count": self.transactions.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.cache.clear();
+        self.transactions.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DocumentCache {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    pub cache: HashMap<String, Value>,
+    pub documents: HashMap<String, Value>,
+}
+
+impl DocumentCache {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            cache: HashMap::new(),
+            documents: HashMap::new(),
+        }
+    }
+}
+
+impl Default for DocumentCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for DocumentCache {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "DocumentCache"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let doc_id = data
+            .get("doc_id")
+            .or_else(|| data.get("document_id"))
+            .or_else(|| data.get("key"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| compute_digest_value(&message.data));
+
+        if data.get("action").and_then(|v| v.as_str()) == Some("delete") {
+            self.documents.remove(&doc_id);
+            self.cache.remove(&doc_id);
+            self.storage.delete(&format!("doc:{doc_id}")).await;
+            return Ok(());
+        }
+
+        let payload = data
+            .get("document")
+            .cloned()
+            .or_else(|| data.get("value").cloned())
+            .unwrap_or(Value::Object(data));
+        self.documents.insert(doc_id.clone(), payload.clone());
+        self.cache.insert(doc_id.clone(), payload.clone());
+        self.storage.write(&format!("doc:{doc_id}"), payload).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"document_count": self.documents.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.cache.clear();
+        self.documents.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 // Modules
 pub mod consensus;
+pub mod core_objects;
 pub mod crypto;
 pub mod discovery;
 pub mod error;
@@ -29,6 +30,11 @@ pub use node::{clear_local_registry, ChaincraftNode};
 pub use shared::{SharedMessage, SharedObject, SharedObjectId, SharedObjectRegistry};
 
 // Application object re-exports
+pub use core_objects::{
+    BalanceLedger, Blockchain, CacheObject, CoreSharedObject, DAGObject, DocumentCache, Mempool,
+    MerkelizedObject, MerkleizedObject, NativeSharedObject, NonMerkelizedObject, TransactionChain,
+    UTXOLedger,
+};
 pub use shared_object::{
     ApplicationObject, ApplicationObjectRegistry, MerkelizedChain, MessageChain, SimpleSharedNumber,
 };

--- a/tests/test_core_objects.rs
+++ b/tests/test_core_objects.rs
@@ -1,0 +1,172 @@
+use chaincraft::shared::{MessageType, SharedMessage};
+use chaincraft::shared_object::ApplicationObject;
+use chaincraft::{
+    BalanceLedger, Blockchain, CacheObject, CoreSharedObject, DAGObject, DocumentCache, Mempool,
+    MerkelizedObject, NonMerkelizedObject, TransactionChain, UTXOLedger,
+};
+
+fn msg(data: serde_json::Value) -> SharedMessage {
+    SharedMessage::new(MessageType::Custom("test".to_string()), data)
+}
+
+#[tokio::test]
+async fn test_core_digest_stability() {
+    let a = serde_json::json!({"b": 2, "a": 1});
+    let b = serde_json::json!({"a": 1, "b": 2});
+    assert_eq!(CoreSharedObject::compute_digest(&a), CoreSharedObject::compute_digest(&b));
+}
+
+#[tokio::test]
+async fn test_non_merkelized_stubs() {
+    for obj in &mut [
+        Box::new(NonMerkelizedObject::new()) as Box<dyn ApplicationObject>,
+        Box::new(CacheObject::new()),
+        Box::new(Mempool::new()),
+        Box::new(DocumentCache::new()),
+    ] {
+        assert!(!obj.is_merkleized());
+        assert_eq!(obj.get_latest_digest().await.unwrap(), "");
+        assert!(!obj.has_digest("abc").await.unwrap());
+        assert!(!obj.is_valid_digest("abc").await.unwrap());
+        assert!(!obj.add_digest("abc".to_string()).await.unwrap());
+        assert!(obj.gossip_messages(Some("abc")).await.unwrap().is_empty());
+        assert!(obj
+            .get_messages_since_digest("abc")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}
+
+#[tokio::test]
+async fn test_merkelized_object_basic_digest_flow() {
+    let mut obj = MerkelizedObject::new();
+    obj.add_message(msg(serde_json::json!({"i": 1})))
+        .await
+        .unwrap();
+    let d1 = obj.get_latest_digest().await.unwrap();
+    obj.add_message(msg(serde_json::json!({"i": 2})))
+        .await
+        .unwrap();
+    let d2 = obj.get_latest_digest().await.unwrap();
+    assert_ne!(d1, "");
+    assert_ne!(d1, d2);
+    assert_eq!(obj.get_messages_since_digest(&d1).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_utxo_add_spend_flow() {
+    let mut ledger = UTXOLedger::new();
+    let add = msg(serde_json::json!({
+        "action": "utxo_add",
+        "utxo_id": "u1",
+        "amount": 5,
+        "owner": "alice"
+    }));
+    assert!(ledger.is_valid(&add).await.unwrap());
+    ledger.add_message(add).await.unwrap();
+    assert!(ledger.utxos.contains_key("u1"));
+
+    let spend = msg(serde_json::json!({"action": "utxo_spend", "utxo_id": "u1"}));
+    assert!(ledger.is_valid(&spend).await.unwrap());
+    ledger.add_message(spend).await.unwrap();
+    assert!(!ledger.utxos.contains_key("u1"));
+}
+
+#[tokio::test]
+async fn test_balance_ledger_credit_debit_transfer() {
+    let mut ledger = BalanceLedger::new();
+    ledger
+        .add_message(msg(serde_json::json!({
+            "action": "credit",
+            "account": "alice",
+            "amount": 10.0
+        })))
+        .await
+        .unwrap();
+    let debit = msg(serde_json::json!({"action": "debit", "account": "alice", "amount": 3.0}));
+    assert!(ledger.is_valid(&debit).await.unwrap());
+    ledger.add_message(debit).await.unwrap();
+
+    let transfer = msg(serde_json::json!({
+        "action": "transfer",
+        "from": "alice",
+        "to": "bob",
+        "amount": 4.0
+    }));
+    assert!(ledger.is_valid(&transfer).await.unwrap());
+    ledger.add_message(transfer).await.unwrap();
+    assert_eq!(ledger.balances.get("alice").cloned().unwrap_or(0.0), 3.0);
+    assert_eq!(ledger.balances.get("bob").cloned().unwrap_or(0.0), 4.0);
+}
+
+#[tokio::test]
+async fn test_blockchain_previous_digest_rules() {
+    let mut chain = Blockchain::new();
+    let genesis = msg(serde_json::json!({"previous_digest": "genesis", "height": 1}));
+    assert!(chain.is_valid(&genesis).await.unwrap());
+    chain.add_message(genesis).await.unwrap();
+    let prev = chain.blocks[0]["digest"].as_str().unwrap().to_string();
+    let next = msg(serde_json::json!({"previous_digest": prev, "height": 2}));
+    assert!(chain.is_valid(&next).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_dag_frontier_and_since_digest() {
+    let mut dag = DAGObject::new();
+    dag.add_message(msg(serde_json::json!({"parents": [], "payload": "root"})))
+        .await
+        .unwrap();
+    let root = dag.get_head_digests()[0].clone();
+    dag.add_message(msg(serde_json::json!({"parents": [root], "payload": "child"})))
+        .await
+        .unwrap();
+    let checkpoint = dag.get_latest_digest().await.unwrap();
+    let head = dag.get_head_digests()[0].clone();
+    dag.add_message(msg(serde_json::json!({"parents": [head], "payload": "child-2"})))
+        .await
+        .unwrap();
+    let delta = dag.get_messages_since_digest(&checkpoint).await.unwrap();
+    assert_eq!(delta.len(), 1);
+}
+
+#[tokio::test]
+async fn test_transaction_chain_tracks_order() {
+    let mut chain = TransactionChain::new();
+    chain
+        .add_message(msg(serde_json::json!({"tx_id": "a", "amount": 1})))
+        .await
+        .unwrap();
+    let d1 = chain.get_latest_digest().await.unwrap();
+    chain
+        .add_message(msg(serde_json::json!({"tx_id": "b", "amount": 2})))
+        .await
+        .unwrap();
+    assert_eq!(chain.transactions.len(), 2);
+    assert_eq!(chain.get_messages_since_digest(&d1).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_mempool_and_document_cache_ops() {
+    let mut mempool = Mempool::new();
+    mempool
+        .add_message(msg(serde_json::json!({"from": "a", "to": "b", "amount": 1})))
+        .await
+        .unwrap();
+    assert_eq!(mempool.transactions.len(), 1);
+    let tx_id = mempool.transactions.keys().next().unwrap().clone();
+    mempool
+        .add_message(msg(serde_json::json!({"tx_id": tx_id, "action": "remove"})))
+        .await
+        .unwrap();
+    assert!(mempool.transactions.is_empty());
+
+    let mut docs = DocumentCache::new();
+    docs.add_message(msg(serde_json::json!({
+        "document_id": "d1",
+        "value": {"title": "hello"}
+    })))
+    .await
+    .unwrap();
+    assert_eq!(docs.documents["d1"]["title"], "hello");
+}

--- a/tests/test_shared_objects.rs
+++ b/tests/test_shared_objects.rs
@@ -1,9 +1,6 @@
 use chaincraft::{
-    clear_local_registry,
-    network::PeerId,
-    shared_object::{ApplicationObject, SimpleSharedNumber},
-    storage::MemoryStorage,
-    ChaincraftNode,
+    clear_local_registry, network::PeerId, shared_object::ApplicationObject,
+    storage::MemoryStorage, BalanceLedger, ChaincraftNode,
 };
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
@@ -20,9 +17,9 @@ async fn create_network(num_nodes: usize) -> Vec<ChaincraftNode> {
         node.set_port(0);
         node.disable_local_discovery();
 
-        // Add a SimpleSharedNumber object to each node
-        let shared_number: Box<dyn ApplicationObject> = Box::new(SimpleSharedNumber::new());
-        node.add_shared_object(shared_number).await.unwrap();
+        // Add a BalanceLedger object to each node.
+        let ledger: Box<dyn ApplicationObject> = Box::new(BalanceLedger::new());
+        node.add_shared_object(ledger).await.unwrap();
 
         node.start().await.unwrap();
         nodes.push(node);
@@ -75,8 +72,13 @@ async fn test_shared_object_propagation() {
 
     // Create messages from each node
     for i in 0..nodes.len() {
-        let value = (i + 1) as i64;
-        let data = serde_json::json!(value);
+        let value = (i + 1) as f64;
+        let account = format!("user-{i}");
+        let data = serde_json::json!({
+            "action": "credit",
+            "account": account,
+            "amount": value,
+        });
         nodes[i]
             .create_shared_message_with_data(data)
             .await
@@ -88,29 +90,23 @@ async fn test_shared_object_propagation() {
         for (j, n) in nodes.iter().enumerate() {
             let shared_objects = n.shared_objects().await;
             if let Some(obj) = shared_objects.first() {
-                if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-                    println!("Node {}: Shared number: {}", j, shared_number.get_number());
+                if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+                    println!("Node {}: Ledger entries: {}", j, ledger.balances.len());
                 }
             }
         }
     }
 
-    // Calculate expected total
-    let expected_number: i64 = (1..=num_nodes as i64).sum();
-
-    // Wait for propagation (simplified - in a real network this would involve gossip protocol)
-    // For now, we just verify that each node processed its own message
+    // Wait for propagation (simplified); verify each node processed its own message at least.
     for (i, node) in nodes.iter().enumerate() {
         let shared_objects = node.shared_objects().await;
         if let Some(obj) = shared_objects.first() {
-            if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-                // Each node should have processed at least its own message
-                assert!(shared_number.get_number() >= (i + 1) as i64);
+            if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+                let account = format!("user-{i}");
+                assert!(ledger.balances.get(&account).cloned().unwrap_or(0.0) >= (i + 1) as f64);
             }
         }
     }
-
-    println!("Expected total after all propagation: {expected_number}");
 
     // Clean up
     for mut node in nodes {
@@ -123,8 +119,11 @@ async fn test_message_deduplication() {
     let mut node = create_network(1).await.into_iter().next().unwrap();
 
     // Send the same message multiple times
-    let test_value = 42;
-    let data = serde_json::json!(test_value);
+    let data = serde_json::json!({
+        "action": "credit",
+        "account": "alice",
+        "amount": 42.0,
+    });
 
     for _ in 0..5 {
         node.create_shared_message_with_data(data.clone())
@@ -132,12 +131,11 @@ async fn test_message_deduplication() {
             .unwrap();
     }
 
-    // Verify the shared number only incremented once due to deduplication
+    // Verify the ledger only increments once due to digest deduplication.
     let shared_objects = node.shared_objects().await;
     if let Some(obj) = shared_objects.first() {
-        if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-            assert_eq!(shared_number.get_number(), test_value);
-            assert_eq!(shared_number.get_messages().len(), 1);
+        if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+            assert_eq!(ledger.balances.get("alice").cloned().unwrap_or(0.0), 42.0);
         }
     }
 
@@ -150,24 +148,26 @@ async fn test_shared_object_state() {
     let mut node = create_network(1).await.into_iter().next().unwrap();
 
     // Add multiple messages
-    let values = vec![10, 20, 30];
+    let values = vec![10.0, 20.0, 30.0];
     for value in &values {
-        let data = serde_json::json!(value);
+        let data = serde_json::json!({
+            "action": "credit",
+            "account": "alice",
+            "amount": value,
+        });
         node.create_shared_message_with_data(data).await.unwrap();
     }
 
     // Verify the state
     let shared_objects = node.shared_objects().await;
     if let Some(obj) = shared_objects.first() {
-        if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-            let expected_sum: i64 = values.iter().sum();
-            assert_eq!(shared_number.get_number(), expected_sum);
-            assert_eq!(shared_number.get_messages().len(), values.len());
+        if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+            let expected_sum: f64 = values.iter().sum();
+            assert_eq!(ledger.balances.get("alice").cloned().unwrap_or(0.0), expected_sum);
 
             // Test state as JSON
             let state = obj.get_state().await.unwrap();
-            assert_eq!(state["number"], expected_sum);
-            assert_eq!(state["message_count"], values.len());
+            assert_eq!(state["balance_count"], 1);
         }
     }
 


### PR DESCRIPTION
 ## Summary
- Port Python-aligned core shared objects into Rust (`CoreSharedObject`, `MerkelizedObject`/`MerkleizedObject`, `UTXOLedger`, `BalanceLedger`, `Blockchain`, `DAGObject`, `TransactionChain`, `CacheObject`, `Mempool`, `DocumentCache`).
- Add Rust protocol spec at `chaincraft-rust/SPECS.md` and export new core objects from `src/lib.rs`.
- Update Rust shared-object example and tests to use migrated core objects, plus add dedicated core-object test coverage.
- Bump Rust crate version to `0.3.0` (`Cargo.toml`, `Cargo.lock`, `README.md`, `CHANGELOG.md`).

## Test Plan
- `cargo fmt`
- `cargo test --test test_core_objects -- --nocapture`
- `cargo test --test test_shared_objects -- --nocapture`

## Notes
- Changes were done on branch: `chore/migrate-python-core-objects`
- Includes both feature migration and release/version bump in one PR.