### PR TITLE
feat(examples): add Snowflake and Snowball Rust examples with typed protocol node wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-07
+
+### Changed
+- Bump crate version to 0.3.0.
+- Migrate Python-aligned core shared objects into Rust.
+
 ## [0.2.4] - 2025-03-12
 
 ### Fixed
@@ -78,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable resource limits
 - Optimized cryptographic operations
 
-[Unreleased]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.2...v0.2.4
 [0.2.2]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/jose-blockchain/chaincraft-rust/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaincraft"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaincraft"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaincraft"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaincraft"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Chaincraft Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaincraft"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Chaincraft Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaincraft"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Chaincraft Contributors"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add Chaincraft Rust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = "0.2.4"
+chaincraft = "0.3.0"
 ```
 
 ### Basic Example
@@ -195,7 +195,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = { version = "0.2.4", features = ["persistent", "indexing"] }
+chaincraft = { version = "0.3.0", features = ["persistent", "indexing"] }
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add Chaincraft Rust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = "0.3.1"
+chaincraft = "0.3.2"
 ```
 
 ### Basic Example
@@ -195,7 +195,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = { version = "0.3.1", features = ["persistent", "indexing"] }
+chaincraft = { version = "0.3.2", features = ["persistent", "indexing"] }
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add Chaincraft Rust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = "0.3.0"
+chaincraft = "0.3.1"
 ```
 
 ### Basic Example
@@ -195,7 +195,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = { version = "0.3.0", features = ["persistent", "indexing"] }
+chaincraft = { version = "0.3.1", features = ["persistent", "indexing"] }
 ```
 
 ## Development

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,0 +1,104 @@
+# Chaincraft Rust Protocol Specification v1
+
+This document describes how to implement a protocol in `chaincraft-rust`.
+
+You implement protocol logic; Chaincraft handles networking, gossip, storage,
+peer management, and runtime concurrency.
+
+## Core Abstractions
+
+### SharedMessage
+
+`SharedMessage` is the transport envelope for JSON data exchanged between nodes.
+
+```rust
+use chaincraft::shared::{MessageType, SharedMessage};
+
+let msg = SharedMessage::new(
+    MessageType::Custom("MY_VOTE".to_string()),
+    serde_json::json!({"value": 42}),
+);
+```
+
+### ApplicationObject
+
+Protocols are implemented as `ApplicationObject` objects.
+
+Key methods:
+
+- `is_valid(&self, message)` for validation
+- `add_message(&mut self, message)` for state transition
+- `is_merkleized()` and digest methods for sync strategy
+- `gossip_messages()` / `get_messages_since_digest()` for sync deltas
+
+### ChaincraftNode
+
+`ChaincraftNode` is the runtime:
+
+- receives messages
+- stores and broadcasts accepted messages
+- dispatches each message to registered application objects
+
+## Message Flow
+
+For incoming or locally-created gossip messages:
+
+1. Build or parse `SharedMessage`.
+2. Pass through registered application objects.
+3. Store in node storage.
+4. Broadcast to peers.
+
+Each object should keep protocol routing inside `add_message` and call private
+helpers for concrete state transitions.
+
+## Merkelized vs Non-Merkelized Objects
+
+Use merkelized objects when digest-based synchronization matters (chains, DAGs,
+state ledgers).
+
+Use non-merkelized objects for eventually-consistent, gossip-only state where
+digest state proofs are unnecessary (cache/mempool-like queues).
+
+## Rust Core Objects
+
+The Rust crate exposes Python-aligned core objects:
+
+- Merkelized:
+  - `MerkelizedObject`
+  - `UTXOLedger`
+  - `BalanceLedger`
+  - `Blockchain`
+  - `DAGObject`
+  - `TransactionChain`
+- Non-merkelized:
+  - `NonMerkelizedObject`
+  - `CacheObject`
+  - `Mempool`
+  - `DocumentCache`
+
+Compatibility aliases:
+
+- `MerkleizedObject` -> `MerkelizedObject`
+- `NativeSharedObject` -> `CoreSharedObject`
+
+## Object Registration
+
+```rust
+use chaincraft::{
+    network::PeerId,
+    storage::MemoryStorage,
+    BalanceLedger, ChaincraftNode,
+};
+use std::sync::Arc;
+
+let storage = Arc::new(MemoryStorage::new());
+let mut node = ChaincraftNode::new(PeerId::new(), storage);
+node.add_shared_object(Box::new(BalanceLedger::new())).await?;
+```
+
+## Guidance
+
+- Keep validation logic strict in `is_valid`.
+- Keep state mutation in `add_message`.
+- Use digest methods only for merkelized objects.
+- Avoid direct network/thread management in protocol objects.

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,67 +1,177 @@
 # Chaincraft Rust Protocol Specification v1
 
-This document describes how to implement a protocol in `chaincraft-rust`.
+This document describes how to implement protocols with `chaincraft-rust`.
 
-You implement protocol logic; Chaincraft handles networking, gossip, storage,
-peer management, and runtime concurrency.
+You write protocol/application logic; Chaincraft runtime handles UDP networking,
+message propagation, deduplication, storage, peer tracking, and background tasks.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                        ChaincraftNode                        │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ start_networking()                                    │  │
+│  │ - UDP receive loop                                    │  │
+│  │ - gossip rebroadcast loop                             │  │
+│  │ - digest sync control path                            │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                                                              │
+│  app_objects: ApplicationObjectRegistry                      │
+│     └── process_message(msg):                                │
+│         - object.is_valid(msg)                               │
+│         - if valid => object.add_message(msg)                │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
 
 ## Core Abstractions
 
-### SharedMessage
+### `SharedMessage`
 
-`SharedMessage` is the transport envelope for JSON data exchanged between nodes.
+Transport envelope exchanged between nodes as JSON.
+
+Key fields:
+
+- `id: SharedObjectId`
+- `message_type: MessageType`
+- `target_id: Option<SharedObjectId>`
+- `data: serde_json::Value`
+- `timestamp`
+- `signature: Option<Vec<u8>>`
+- `hash`
+
+Create messages with:
 
 ```rust
 use chaincraft::shared::{MessageType, SharedMessage};
 
 let msg = SharedMessage::new(
     MessageType::Custom("MY_VOTE".to_string()),
-    serde_json::json!({"value": 42}),
+    serde_json::json!({"round": 7, "vote": "yes"}),
 );
 ```
 
-### ApplicationObject
+### `ApplicationObject`
 
-Protocols are implemented as `ApplicationObject` objects.
+Protocols are implemented as `ApplicationObject` implementations.
 
-Key methods:
+Main methods:
 
-- `is_valid(&self, message)` for validation
-- `add_message(&mut self, message)` for state transition
-- `is_merkleized()` and digest methods for sync strategy
-- `gossip_messages()` / `get_messages_since_digest()` for sync deltas
+- `is_valid(&self, message) -> Result<bool>`
+- `add_message(&mut self, message) -> Result<()>`
+- `is_merkleized() -> bool`
+- digest methods (`get_latest_digest`, `has_digest`, `is_valid_digest`, `add_digest`)
+- sync methods (`gossip_messages`, `get_messages_since_digest`)
+- lifecycle/state (`get_state`, `reset`)
 
-### ChaincraftNode
+### `ChaincraftNode`
 
-`ChaincraftNode` is the runtime:
+Runtime entrypoint for networking and protocol dispatch.
 
-- receives messages
-- stores and broadcasts accepted messages
-- dispatches each message to registered application objects
+Important methods:
 
-## Message Flow
+- `start()` / `close()`
+- `connect_to_peer("host:port")`
+- `add_shared_object(Box<dyn ApplicationObject>)`
+- `create_shared_message_with_data(serde_json::Value)`
+- `create_shared_message(String)` (compatibility helper)
 
-For incoming or locally-created gossip messages:
+## Message Types and P2P Control Messages
 
-1. Build or parse `SharedMessage`.
-2. Pass through registered application objects.
-3. Store in node storage.
-4. Broadcast to peers.
+`MessageType` supports both application messages and protocol control plane messages.
 
-Each object should keep protocol routing inside `add_message` and call private
-helpers for concrete state transitions.
+Built-in control types include:
+
+- `PEER_DISCOVERY`, `REQUEST_LOCAL_PEERS`, `LOCAL_PEERS`
+- `REQUEST_SHARED_OBJECT_UPDATE`, `SHARED_OBJECT_UPDATE`
+- `REQUEST_DIGEST`, `DIGEST_RESPONSE`
+- `REQUEST_MESSAGES_SINCE`, `MESSAGES_RESPONSE`
+- `GET`, `SET`, `DELETE`, `RESPONSE`, `NOTIFICATION`, `HEARTBEAT`, `ERROR`
+
+For protocol-specific traffic, use `MessageType::Custom("...")`.
+
+Example data payload with explicit type:
+
+```rust
+let data = serde_json::json!({
+    "type": "SLUSH_VOTE",
+    "round": 3,
+    "color": "red"
+});
+node.create_shared_message_with_data(data).await?;
+```
+
+## Message Flow (Gossip/Data Path)
+
+### Outbound (local create)
+
+`create_shared_message_with_data(data)` performs:
+
+1. Resolve `MessageType` from `data["type"]` (or default custom type).
+2. Build `SharedMessage`.
+3. Store message in node storage.
+4. Run `ApplicationObjectRegistry::process_message`.
+5. Broadcast JSON payload over UDP to known peers.
+
+### Inbound (from peer datagram)
+
+Receive loop performs:
+
+1. Parse control/digest messages first.
+2. Else parse datagram as `SharedMessage`.
+3. Deduplicate by `hash` (skip if already stored).
+4. Store in node storage.
+5. Dispatch via `process_message`.
+6. Re-broadcast to peers for propagation.
+
+## Request/Response and Sync Path
+
+Rust runtime includes a control-plane request/response path over UDP JSON:
+
+- `REQUEST_DIGEST` -> `DIGEST_RESPONSE`
+- `REQUEST_MESSAGES_SINCE` -> `MESSAGES_RESPONSE`
+
+When digests differ, peers request missing messages and apply them through the
+same `process_message` path used by normal gossip.
+
+This is the Rust equivalent of direct synchronization traffic: messages are
+point-to-point UDP exchanges but still represented in JSON and integrated with
+object-level digest methods.
+
+## Validation and Processing Semantics
+
+`ApplicationObjectRegistry::process_message` evaluates each registered object
+sequentially:
+
+1. `object.is_valid(&message)`
+2. If valid for that object, call `object.add_message(message.clone())`
+3. Continue to next object
+
+Important: processing is per-object. A rejection in one object does not prevent
+other objects from processing if they validate the same message.
 
 ## Merkelized vs Non-Merkelized Objects
 
-Use merkelized objects when digest-based synchronization matters (chains, DAGs,
-state ledgers).
+Use merkelized objects when digest-based state sync matters:
 
-Use non-merkelized objects for eventually-consistent, gossip-only state where
-digest state proofs are unnecessary (cache/mempool-like queues).
+- chains
+- DAGs
+- ledgers/state snapshots
+
+Use non-merkelized objects when gossip plus hash deduplication is enough:
+
+- mempool queues
+- transient caches
+- loosely ordered event streams
+
+For non-merkelized objects, keep digest methods simple/minimal and return empty
+sync payloads as appropriate.
 
 ## Rust Core Objects
 
-The Rust crate exposes Python-aligned core objects:
+The crate exposes Python-aligned core objects:
 
 - Merkelized:
   - `MerkelizedObject`
@@ -81,14 +191,18 @@ Compatibility aliases:
 - `MerkleizedObject` -> `MerkelizedObject`
 - `NativeSharedObject` -> `CoreSharedObject`
 
-## Object Registration
+## Implementing a Protocol
+
+### 1) Define an `ApplicationObject`
+
+- Keep structural/state checks in `is_valid`.
+- Keep mutations in `add_message`.
+- Route by `message.message_type` or `message.data["type"]` inside `add_message`.
+
+### 2) Register object(s) on a node
 
 ```rust
-use chaincraft::{
-    network::PeerId,
-    storage::MemoryStorage,
-    BalanceLedger, ChaincraftNode,
-};
+use chaincraft::{network::PeerId, storage::MemoryStorage, BalanceLedger, ChaincraftNode};
 use std::sync::Arc;
 
 let storage = Arc::new(MemoryStorage::new());
@@ -96,9 +210,35 @@ let mut node = ChaincraftNode::new(PeerId::new(), storage);
 node.add_shared_object(Box::new(BalanceLedger::new())).await?;
 ```
 
-## Guidance
+### 3) Start networking and connect peers
 
-- Keep validation logic strict in `is_valid`.
-- Keep state mutation in `add_message`.
-- Use digest methods only for merkelized objects.
-- Avoid direct network/thread management in protocol objects.
+```rust
+node.start().await?;
+node.connect_to_peer("127.0.0.1:9001").await?;
+```
+
+### 4) Publish protocol messages
+
+```rust
+node.create_shared_message_with_data(serde_json::json!({
+    "type": "MY_PROTOCOL_EVENT",
+    "payload": {"x": 42}
+})).await?;
+```
+
+## Threading and Concurrency Guidance
+
+- Do not manage sockets or manual networking in protocol objects.
+- Do not create parallel protocol runtimes for message handling.
+- Keep object logic deterministic and idempotent where possible.
+- If external tasks touch shared protocol state, protect internal invariants.
+
+## What Protocol Authors Should Not Reimplement
+
+- UDP gossip fanout
+- message hash deduplication
+- peer discovery bookkeeping
+- digest-sync transport exchange
+- node lifecycle orchestration
+
+Use the provided node/runtime APIs and focus on protocol-specific state machines.

--- a/SPECS.md
+++ b/SPECS.md
@@ -8,22 +8,28 @@ message propagation, deduplication, storage, peer tracking, and background tasks
 ## Architecture Overview
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│                        ChaincraftNode                        │
-│                                                              │
-│  ┌────────────────────────────────────────────────────────┐  │
-│  │ start_networking()                                    │  │
-│  │ - UDP receive loop                                    │  │
-│  │ - gossip rebroadcast loop                             │  │
-│  │ - digest sync control path                            │  │
-│  └────────────────────────────────────────────────────────┘  │
-│                                                              │
-│  app_objects: ApplicationObjectRegistry                      │
-│     └── process_message(msg):                                │
-│         - object.is_valid(msg)                               │
-│         - if valid => object.add_message(msg)                │
-│                                                              │
-└──────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                            ChaincraftNode                            │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │ start_networking()                                             │  │
+│  │ - UDP receive loop                                             │  │
+│  │ - gossip rebroadcast loop                                      │  │
+│  │ - direct control/P2P path (non-gossip sync and requests)       │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                      │
+│  Incoming UDP datagram                                               │
+│   ├── SharedMessage gossip path                                      │
+│   │    ├── dedupe by hash + store                                    │
+│   │    ├── app_objects.process_message(msg)                          │
+│   │    │    ├── object.is_valid(msg)                                 │
+│   │    │    └── if valid => object.add_message(msg)                  │
+│   │    └── rebroadcast to peers                                      │
+│   │                                                                  │
+│   └── Direct control/P2P path (no gossip fanout)                     │
+│        └── REQUEST_DIGEST / REQUEST_MESSAGES_SINCE / responses       │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Core Abstractions

--- a/examples/chatroom_example.rs
+++ b/examples/chatroom_example.rs
@@ -13,13 +13,8 @@
 use chaincraft::{
     crypto::ecdsa::ECDSASigner,
     error::Result,
-    examples::chatroom::{helpers, ChatroomObject},
-    network::PeerId,
-    shared_object::ApplicationObject,
-    storage::MemoryStorage,
-    ChaincraftNode,
+    examples::chatroom::{helpers, ChatroomNode},
 };
-use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
 #[tokio::main]
@@ -29,12 +24,7 @@ async fn main() -> Result<()> {
     println!("Chaincraft Chatroom Example");
     println!("===========================\n");
 
-    let id = PeerId::new();
-    let storage = Arc::new(MemoryStorage::new());
-    let mut node = ChaincraftNode::new(id, storage);
-
-    let chatroom_obj: Box<dyn ApplicationObject> = Box::new(ChatroomObject::new());
-    node.add_shared_object(chatroom_obj).await?;
+    let mut node = ChatroomNode::new(0).await?;
     node.start().await?;
 
     println!("Node started with peer ID: {}", node.id());
@@ -42,7 +32,7 @@ async fn main() -> Result<()> {
     let admin_signer = ECDSASigner::new()?;
 
     let create_msg = helpers::create_chatroom_message("rust_chatroom".to_string(), &admin_signer)?;
-    node.create_shared_message_with_data(create_msg).await?;
+    node.publish(create_msg).await?;
 
     println!("Created chatroom 'rust_chatroom'");
     sleep(Duration::from_millis(200)).await;
@@ -52,21 +42,17 @@ async fn main() -> Result<()> {
         "Hello from Chaincraft Rust!".to_string(),
         &admin_signer,
     )?;
-    node.create_shared_message_with_data(post_msg).await?;
+    node.publish(post_msg).await?;
 
     println!("Posted message to chatroom");
     sleep(Duration::from_millis(200)).await;
 
-    let shared_objects = node.shared_objects().await;
-    if let Some(obj) = shared_objects.first() {
-        if let Some(chatroom_obj) = obj.as_any().downcast_ref::<ChatroomObject>() {
-            let chatrooms = chatroom_obj.get_chatrooms();
-            println!("\nChatrooms: {:?}", chatrooms.keys().collect::<Vec<_>>());
-            if let Some(room) = chatrooms.get("rust_chatroom") {
-                println!("Messages in rust_chatroom: {}", room.messages.len());
-            }
-        }
-    }
+    let names = node.chatroom_names().await?;
+    println!("\nChatrooms: {names:?}");
+    println!(
+        "Messages in rust_chatroom: {}",
+        node.chatroom_message_count("rust_chatroom").await?
+    );
 
     println!("\nShutting down...");
     node.close().await?;

--- a/examples/ecdsa_ledger_example.rs
+++ b/examples/ecdsa_ledger_example.rs
@@ -6,12 +6,8 @@
 use chaincraft::{
     crypto::ecdsa::ECDSASigner,
     error::Result,
-    examples::ecdsa_ledger::{helpers, ECDSALedgerObject},
-    network::PeerId,
-    storage::MemoryStorage,
-    ChaincraftNode,
+    examples::ecdsa_ledger::{helpers, ECDSALedgerNode},
 };
-use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
 #[tokio::main]
@@ -21,12 +17,7 @@ async fn main() -> Result<()> {
     println!("Chaincraft ECDSA Ledger Example");
     println!("===============================\n");
 
-    let id = PeerId::new();
-    let storage = Arc::new(MemoryStorage::new());
-    let mut node = ChaincraftNode::new(id, storage);
-    node.set_port(0);
-    node.add_shared_object(Box::new(ECDSALedgerObject::new()))
-        .await?;
+    let mut node = ECDSALedgerNode::new(0).await?;
     node.start().await?;
 
     let alice = ECDSASigner::new()?;
@@ -36,24 +27,19 @@ async fn main() -> Result<()> {
 
     // Alice "mints" 100 (first tx from new address)
     let tx1 = helpers::create_transfer(alice_pk.clone(), bob_pk.clone(), 50, 0, &alice)?;
-    node.create_shared_message_with_data(tx1).await?;
+    node.publish(tx1).await?;
     println!("Alice -> Bob: 50 (first tx = mint)");
     sleep(Duration::from_millis(200)).await;
 
     // Bob -> Alice: 20
     let tx2 = helpers::create_transfer(bob_pk.clone(), alice_pk.clone(), 20, 0, &bob)?;
-    node.create_shared_message_with_data(tx2).await?;
+    node.publish(tx2).await?;
     println!("Bob -> Alice: 20");
     sleep(Duration::from_millis(200)).await;
 
-    let objs = node.shared_objects().await;
-    if let Some(obj) = objs.first() {
-        if let Some(ledger) = obj.as_any().downcast_ref::<ECDSALedgerObject>() {
-            println!("\nLedger entries: {}", ledger.entries().len());
-            println!("Alice balance: {}", ledger.balance(&alice_pk));
-            println!("Bob balance: {}", ledger.balance(&bob_pk));
-        }
-    }
+    println!("\nLedger entries: {}", node.entry_count().await?);
+    println!("Alice balance: {}", node.balance(&alice_pk).await?);
+    println!("Bob balance: {}", node.balance(&bob_pk).await?);
 
     node.close().await?;
     println!("Done.");

--- a/examples/randomness_beacon_example.rs
+++ b/examples/randomness_beacon_example.rs
@@ -12,13 +12,8 @@
 
 use chaincraft::{
     error::Result,
-    examples::randomness_beacon::{helpers, RandomnessBeaconObject},
-    network::PeerId,
-    shared_object::ApplicationObject,
-    storage::MemoryStorage,
-    ChaincraftNode,
+    examples::randomness_beacon::{helpers, RandomnessBeaconNode},
 };
-use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
 #[tokio::main]
@@ -28,16 +23,9 @@ async fn main() -> Result<()> {
     println!("Chaincraft Randomness Beacon Example");
     println!("=====================================\n");
 
-    let beacon = RandomnessBeaconObject::new(60, 2)?;
-    let my_address = beacon.my_validator_address.clone();
-
-    let id = PeerId::new();
-    let storage = Arc::new(MemoryStorage::new());
-    let mut node = ChaincraftNode::new(id, storage);
-
-    let beacon_obj: Box<dyn ApplicationObject> = Box::new(beacon);
-    node.add_shared_object(beacon_obj).await?;
+    let mut node = RandomnessBeaconNode::new(0, 60, 2).await?;
     node.start().await?;
+    let my_address = node.validator_address().await?;
 
     println!(
         "Node started. Validator address: {}...",
@@ -53,17 +41,12 @@ async fn main() -> Result<()> {
         &reg_signer,
     )?;
 
-    node.create_shared_message_with_data(reg_msg).await?;
+    node.publish(reg_msg).await?;
     println!("Validator registration sent");
     sleep(Duration::from_millis(200)).await;
 
-    let shared_objects = node.shared_objects().await;
-    if let Some(obj) = shared_objects.first() {
-        if obj.type_name() == "RandomnessBeacon" {
-            let state = obj.get_state().await?;
-            println!("\nBeacon state: {}", serde_json::to_string_pretty(&state).unwrap());
-        }
-    }
+    let state = node.beacon_state().await?;
+    println!("\nBeacon state: {}", serde_json::to_string_pretty(&state).unwrap());
 
     println!("\nShutting down...");
     node.close().await?;

--- a/examples/shared_objects_example.rs
+++ b/examples/shared_objects_example.rs
@@ -11,11 +11,8 @@
 //! Run with: `cargo run --example shared_objects_example`
 
 use chaincraft::{
-    error::Result,
-    network::PeerId,
-    shared_object::{ApplicationObject, SimpleSharedNumber},
-    storage::MemoryStorage,
-    ChaincraftNode,
+    error::Result, network::PeerId, shared_object::ApplicationObject, storage::MemoryStorage,
+    BalanceLedger, ChaincraftNode,
 };
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
@@ -29,8 +26,8 @@ async fn create_network(num_nodes: usize) -> Result<Vec<ChaincraftNode>> {
         let storage = Arc::new(MemoryStorage::new());
         let mut node = ChaincraftNode::new(id, storage);
 
-        let shared_number: Box<dyn ApplicationObject> = Box::new(SimpleSharedNumber::new());
-        node.add_shared_object(shared_number).await?;
+        let ledger: Box<dyn ApplicationObject> = Box::new(BalanceLedger::new());
+        node.add_shared_object(ledger).await?;
         node.start().await?;
         nodes.push(node);
     }
@@ -85,12 +82,16 @@ async fn main() -> Result<()> {
 
     for i in 0..3 {
         let node_idx = i % nodes.len();
-        let value = (i + 1) as i64;
-        let data = serde_json::json!(value);
+        let value = (i + 1) as f64;
+        let data = serde_json::json!({
+            "action": "credit",
+            "account": format!("user-{node_idx}"),
+            "amount": value
+        });
         nodes[node_idx]
             .create_shared_message_with_data(data)
             .await?;
-        println!("Node {node_idx} created shared object (value={value})");
+        println!("Node {node_idx} credited user-{node_idx} with {value}");
         sleep(Duration::from_millis(500)).await;
     }
 

--- a/examples/slush_example.rs
+++ b/examples/slush_example.rs
@@ -9,32 +9,9 @@
 use chaincraft::{
     clear_local_registry,
     error::Result,
-    examples::slush::{create_vote_message, Color, SlushObject},
-    network::PeerId,
-    shared_object::ApplicationObject,
-    storage::MemoryStorage,
-    ChaincraftNode,
+    examples::slush::{Color, SlushNode},
 };
-use std::sync::Arc;
 use tokio::time::{sleep, Duration};
-
-async fn create_slush_node(
-    node_id: &str,
-    port: u16,
-    k: usize,
-    alpha: f64,
-    m: u32,
-) -> Result<ChaincraftNode> {
-    let id = PeerId::new();
-    let storage = Arc::new(MemoryStorage::new());
-    let mut node = ChaincraftNode::new(id, storage);
-    node.set_port(port);
-    let slush: Box<dyn ApplicationObject> =
-        Box::new(SlushObject::new(node_id.to_string(), k, alpha, m));
-    node.add_shared_object(slush).await?;
-    node.start().await?;
-    Ok(node)
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -53,10 +30,11 @@ async fn main() -> Result<()> {
     println!("Nodes: {num_nodes}, k: {k}, alpha: {alpha}, rounds: {m}");
     println!("Proposer (node-0) initial color: {initial_color}\n");
 
-    let mut nodes: Vec<ChaincraftNode> = Vec::new();
+    let mut nodes: Vec<SlushNode> = Vec::new();
     for i in 0..num_nodes {
         let node_id = format!("node-{i}");
-        let node = create_slush_node(&node_id, base_port + i as u16, k, alpha, m).await?;
+        let mut node = SlushNode::new(node_id, base_port + i as u16, k, alpha, m).await?;
+        node.start().await?;
         nodes.push(node);
     }
 
@@ -70,58 +48,26 @@ async fn main() -> Result<()> {
     }
     sleep(Duration::from_millis(500)).await;
 
-    // Set proposer color
-    {
-        let objs = nodes[0].shared_objects().await;
-        if let Some(obj) = objs.first() {
-            if let Some(_slush) = obj.as_any().downcast_ref::<SlushObject>() {
-                // We need mutable access via the registry
-            }
-        }
-    }
-    // Proposer broadcasts initial vote for round 0
-    {
-        let vote = create_vote_message("node-0", 0, initial_color);
-        nodes[0].create_shared_message_with_data(vote).await?;
-        println!("[node-0] Proposed {initial_color}");
-    }
+    nodes[0].publish_vote(0, initial_color).await?;
+    println!("[node-0] Proposed {initial_color}");
     sleep(Duration::from_millis(500)).await;
 
     // Run m rounds
     for round in 1..=m {
         // Each node broadcasts its current color
-        for (i, node) in nodes.iter_mut().enumerate() {
-            let node_id = format!("node-{i}");
-            let color = {
-                let objs = node.shared_objects().await;
-                objs.first()
-                    .and_then(|o| o.as_any().downcast_ref::<SlushObject>())
-                    .and_then(|s| s.color)
-                    .unwrap_or(initial_color)
-            };
-            let vote = create_vote_message(&node_id, round, color);
-            node.create_shared_message_with_data(vote).await?;
+        for node in &mut nodes {
+            let color = node.color().await?.unwrap_or(initial_color);
+            node.publish_vote(round, color).await?;
         }
 
         sleep(Duration::from_millis(300)).await;
 
         // Each node processes votes and potentially flips
         for (i, node) in nodes.iter_mut().enumerate() {
-            let mut registry = node.app_objects.write().await;
-            let ids = registry.ids();
-            for id in ids {
-                if let Some(obj) = registry.objects.get_mut(&id) {
-                    if let Some(slush) = obj.as_any_mut().downcast_mut::<SlushObject>() {
-                        let flipped = slush.process_round(round);
-                        slush.current_round = round;
-                        if flipped {
-                            println!(
-                                "  [node-{i}] Round {round}: flipped to {}",
-                                slush.color.unwrap()
-                            );
-                        }
-                    }
-                }
+            let flipped = node.process_round(round).await?;
+            if flipped {
+                let color = node.color().await?.unwrap_or(initial_color);
+                println!("  [node-{i}] Round {round}: flipped to {color}");
             }
         }
     }
@@ -129,19 +75,8 @@ async fn main() -> Result<()> {
     // Finalize
     println!("\n=== Slush consensus complete ===");
     for (i, node) in nodes.iter_mut().enumerate() {
-        let mut registry = node.app_objects.write().await;
-        let ids = registry.ids();
-        for id in ids {
-            if let Some(obj) = registry.objects.get_mut(&id) {
-                if let Some(slush) = obj.as_any_mut().downcast_mut::<SlushObject>() {
-                    slush.finalize();
-                    println!(
-                        "  node-{i}: accepted={}",
-                        slush.accepted.map(|c| c.to_string()).unwrap_or("?".into())
-                    );
-                }
-            }
-        }
+        let accepted = node.finalize().await?;
+        println!("  node-{i}: accepted={}", accepted.map(|c| c.to_string()).unwrap_or("?".into()));
     }
 
     for mut node in nodes {

--- a/examples/snowball_example.rs
+++ b/examples/snowball_example.rs
@@ -1,0 +1,96 @@
+//! Snowball Consensus Example
+//!
+//! Port of the Python `examples/snowball_protocol.py` into Rust-style
+//! Chaincraft usage with gossip-based vote messages.
+//!
+//! Run with: `cargo run --example snowball_example`
+
+use chaincraft::{
+    clear_local_registry,
+    error::Result,
+    examples::snowball::{Color, SnowballNode},
+};
+use tokio::time::{sleep, Duration};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    clear_local_registry();
+
+    let num_nodes: usize = 10;
+    let k: usize = 4;
+    let alpha: f64 = 0.5;
+    let beta: u32 = 8;
+    let base_port: u16 = 9600;
+    let initial_color = Color::Red;
+
+    println!("Snowball Consensus Example");
+    println!("==========================");
+    println!("Nodes: {num_nodes}, k: {k}, alpha: {alpha}, beta: {beta}");
+    println!("Proposer (node-0) initial color: {initial_color}\n");
+
+    let mut nodes: Vec<SnowballNode> = Vec::new();
+    for i in 0..num_nodes {
+        let node_id = format!("node-{i}");
+        let mut node = SnowballNode::new(node_id, base_port + i as u16, k, alpha, beta).await?;
+        node.start().await?;
+        nodes.push(node);
+    }
+
+    for i in 0..num_nodes {
+        for j in 0..num_nodes {
+            if i != j {
+                let addr = format!("{}:{}", nodes[j].host(), nodes[j].port());
+                nodes[i].connect_to_peer(&addr).await?;
+            }
+        }
+    }
+    sleep(Duration::from_millis(500)).await;
+
+    nodes[0].publish_vote(0, initial_color).await?;
+    println!("[node-0] Proposed {initial_color}");
+
+    let max_rounds: u32 = 35;
+    for round in 1..=max_rounds {
+        for node in &mut nodes {
+            let pref = node.preference().await?.unwrap_or(initial_color);
+            node.publish_vote(round, pref).await?;
+        }
+
+        sleep(Duration::from_millis(250)).await;
+
+        for node in &mut nodes {
+            node.process_round(round).await?;
+        }
+        let mut all_done = true;
+        for node in &nodes {
+            if node.accepted().await?.is_none() {
+                all_done = false;
+                break;
+            }
+        }
+        if all_done {
+            println!("All nodes accepted by round {round}");
+            break;
+        }
+    }
+
+    println!("\nFinal Snowball state:");
+    for (i, node) in nodes.iter_mut().enumerate() {
+        let (pref, accepted, conf_r, conf_b, cnt) = node.state_snapshot().await?;
+        println!(
+            "  node-{i}: pref={}, accepted={}, conf(R/B)=({}/{}), cnt={}",
+            pref.map(|c| c.to_string()).unwrap_or("?".into()),
+            accepted.map(|c| c.to_string()).unwrap_or("?".into()),
+            conf_r,
+            conf_b,
+            cnt,
+        );
+    }
+
+    for mut node in nodes {
+        node.close().await?;
+    }
+
+    Ok(())
+}

--- a/examples/snowflake_example.rs
+++ b/examples/snowflake_example.rs
@@ -1,0 +1,94 @@
+//! Snowflake Consensus Example
+//!
+//! Port of the Python `examples/snowflake_protocol.py` into Rust-style
+//! Chaincraft usage with gossip-based vote messages.
+//!
+//! Run with: `cargo run --example snowflake_example`
+
+use chaincraft::{
+    clear_local_registry,
+    error::Result,
+    examples::snowflake::{Color, SnowflakeNode},
+};
+use tokio::time::{sleep, Duration};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    clear_local_registry();
+
+    let num_nodes: usize = 10;
+    let k: usize = 4;
+    let alpha: f64 = 0.5;
+    let beta: u32 = 5;
+    let base_port: u16 = 9500;
+    let initial_color = Color::Red;
+
+    println!("Snowflake Consensus Example");
+    println!("===========================");
+    println!("Nodes: {num_nodes}, k: {k}, alpha: {alpha}, beta: {beta}");
+    println!("Proposer (node-0) initial color: {initial_color}\n");
+
+    let mut nodes: Vec<SnowflakeNode> = Vec::new();
+    for i in 0..num_nodes {
+        let node_id = format!("node-{i}");
+        let mut node = SnowflakeNode::new(node_id, base_port + i as u16, k, alpha, beta).await?;
+        node.start().await?;
+        nodes.push(node);
+    }
+
+    for i in 0..num_nodes {
+        for j in 0..num_nodes {
+            if i != j {
+                let addr = format!("{}:{}", nodes[j].host(), nodes[j].port());
+                nodes[i].connect_to_peer(&addr).await?;
+            }
+        }
+    }
+    sleep(Duration::from_millis(500)).await;
+
+    nodes[0].publish_vote(0, initial_color).await?;
+    println!("[node-0] Proposed {initial_color}");
+
+    let max_rounds: u32 = 25;
+    for round in 1..=max_rounds {
+        for node in &mut nodes {
+            let color = node.color().await?.unwrap_or(initial_color);
+            node.publish_vote(round, color).await?;
+        }
+
+        sleep(Duration::from_millis(250)).await;
+
+        for node in &mut nodes {
+            node.process_round(round).await?;
+        }
+        let mut all_done = true;
+        for node in &nodes {
+            if node.accepted().await?.is_none() {
+                all_done = false;
+                break;
+            }
+        }
+        if all_done {
+            println!("All nodes accepted by round {round}");
+            break;
+        }
+    }
+
+    println!("\nFinal Snowflake state:");
+    for (i, node) in nodes.iter_mut().enumerate() {
+        let (color, accepted, count) = node.state_snapshot().await?;
+        println!(
+            "  node-{i}: color={}, accepted={}, cnt={}",
+            color.map(|c| c.to_string()).unwrap_or("?".into()),
+            accepted.map(|c| c.to_string()).unwrap_or("?".into()),
+            count,
+        );
+    }
+
+    for mut node in nodes {
+        node.close().await?;
+    }
+
+    Ok(())
+}

--- a/src/core_objects.rs
+++ b/src/core_objects.rs
@@ -1,0 +1,1459 @@
+//! Core shared objects aligned with the Python implementation.
+
+use crate::{
+    error::Result,
+    shared::{SharedMessage, SharedObjectId},
+    shared_object::ApplicationObject,
+};
+use async_trait::async_trait;
+use lru::LruCache;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::any::Any;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+type SharedKvBackend = Arc<RwLock<HashMap<String, Value>>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageMode {
+    Memory,
+    Storage,
+}
+
+impl StorageMode {
+    fn from_str(mode: &str) -> Self {
+        if mode == "storage" {
+            Self::Storage
+        } else {
+            Self::Memory
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CoreStorage {
+    persistent: bool,
+    storage_mode: StorageMode,
+    enable_memory_cache: bool,
+    memory_store: HashMap<String, Value>,
+    storage_backend: SharedKvBackend,
+    memory_cache: LruCache<String, Value>,
+}
+
+impl std::fmt::Debug for CoreStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CoreStorage")
+            .field("persistent", &self.persistent)
+            .field("storage_mode", &self.storage_mode)
+            .field("enable_memory_cache", &self.enable_memory_cache)
+            .finish()
+    }
+}
+
+impl CoreStorage {
+    fn new(
+        persistent: bool,
+        storage_mode: StorageMode,
+        storage_backend: Option<SharedKvBackend>,
+        enable_memory_cache: bool,
+        memory_cache_size: usize,
+    ) -> Self {
+        let cache_size = memory_cache_size.max(1);
+        let non_zero = NonZeroUsize::new(cache_size).expect("cache size must be non-zero");
+        Self {
+            persistent,
+            storage_mode,
+            enable_memory_cache,
+            memory_store: HashMap::new(),
+            storage_backend: storage_backend
+                .unwrap_or_else(|| Arc::new(RwLock::new(HashMap::new()))),
+            memory_cache: LruCache::new(non_zero),
+        }
+    }
+
+    async fn read(&mut self, key: &str) -> Option<Value> {
+        if self.enable_memory_cache {
+            if let Some(value) = self.memory_cache.get(key) {
+                return Some(value.clone());
+            }
+        }
+        let value = match self.storage_mode {
+            StorageMode::Memory => self.memory_store.get(key).cloned(),
+            StorageMode::Storage => {
+                let backend = self.storage_backend.read().await;
+                backend.get(key).cloned()
+            },
+        };
+        if self.enable_memory_cache {
+            if let Some(v) = value.clone() {
+                self.memory_cache.put(key.to_string(), v);
+            }
+        }
+        value
+    }
+
+    async fn write(&mut self, key: &str, value: Value) {
+        match self.storage_mode {
+            StorageMode::Memory => {
+                self.memory_store.insert(key.to_string(), value.clone());
+            },
+            StorageMode::Storage => {
+                let mut backend = self.storage_backend.write().await;
+                backend.insert(key.to_string(), value.clone());
+            },
+        }
+        if self.enable_memory_cache {
+            self.memory_cache.put(key.to_string(), value);
+        }
+    }
+
+    async fn delete(&mut self, key: &str) {
+        match self.storage_mode {
+            StorageMode::Memory => {
+                self.memory_store.remove(key);
+            },
+            StorageMode::Storage => {
+                let mut backend = self.storage_backend.write().await;
+                backend.remove(key);
+            },
+        }
+        if self.enable_memory_cache {
+            self.memory_cache.pop(key);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MerkelizedState {
+    messages: Vec<SharedMessage>,
+    digests: Vec<String>,
+    digest_index: HashMap<String, usize>,
+    parents_by_digest: HashMap<String, Vec<String>>,
+    children_by_digest: HashMap<String, HashSet<String>>,
+    head_digests: BTreeSet<String>,
+}
+
+impl MerkelizedState {
+    fn new() -> Self {
+        Self {
+            messages: Vec::new(),
+            digests: Vec::new(),
+            digest_index: HashMap::new(),
+            parents_by_digest: HashMap::new(),
+            children_by_digest: HashMap::new(),
+            head_digests: BTreeSet::new(),
+        }
+    }
+
+    fn latest_digest(&self) -> String {
+        self.digests.last().cloned().unwrap_or_default()
+    }
+
+    fn contains_digest(&self, digest: &str) -> bool {
+        self.digest_index.contains_key(digest)
+    }
+
+    fn head_digest_list(&self) -> Vec<String> {
+        self.head_digests.iter().cloned().collect()
+    }
+
+    async fn record_message(
+        &mut self,
+        storage: &mut CoreStorage,
+        message: SharedMessage,
+        digest: String,
+        parent_digests: Vec<String>,
+    ) {
+        self.messages.push(message.clone());
+        self.digest_index.insert(digest.clone(), self.digests.len());
+        self.digests.push(digest.clone());
+        self.parents_by_digest
+            .insert(digest.clone(), parent_digests.clone());
+
+        for parent in &parent_digests {
+            self.children_by_digest
+                .entry(parent.clone())
+                .or_default()
+                .insert(digest.clone());
+            self.head_digests.remove(parent);
+        }
+        self.children_by_digest.entry(digest.clone()).or_default();
+        self.head_digests.insert(digest.clone());
+        storage.write(&digest, message.data).await;
+    }
+
+    fn messages_since_digest(&self, digest: &str) -> Vec<SharedMessage> {
+        if self.messages.is_empty() {
+            return vec![];
+        }
+        if digest.is_empty() {
+            return self.messages.clone();
+        }
+        let Some(idx) = self.digest_index.get(digest) else {
+            return vec![];
+        };
+        self.messages[(*idx + 1)..].to_vec()
+    }
+}
+
+fn canonical_json(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sorted = std::collections::BTreeMap::new();
+            for (k, v) in map {
+                sorted.insert(k.clone(), canonical_json(v));
+            }
+            let mut out = Map::new();
+            for (k, v) in sorted {
+                out.insert(k, v);
+            }
+            Value::Object(out)
+        },
+        Value::Array(arr) => Value::Array(arr.iter().map(canonical_json).collect()),
+        _ => value.clone(),
+    }
+}
+
+fn compute_digest_value(value: &Value) -> String {
+    let canonical = canonical_json(value);
+    let payload = serde_json::to_string(&canonical).unwrap_or_else(|_| "null".to_string());
+    let mut hasher = Sha256::new();
+    hasher.update(payload.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn normalize_parent_digests_from_value(value: Option<&Value>) -> Vec<String> {
+    let mut normalized = Vec::new();
+    let mut seen = HashSet::new();
+    if let Some(Value::Array(parents)) = value {
+        for p in parents {
+            if let Some(parent) = p.as_str() {
+                if parent.is_empty() || parent == "genesis" {
+                    continue;
+                }
+                if seen.insert(parent.to_string()) {
+                    normalized.push(parent.to_string());
+                }
+            }
+        }
+    }
+    normalized
+}
+
+fn extract_parent_digests(data: &Value) -> Vec<String> {
+    let Some(obj) = data.as_object() else {
+        return vec![];
+    };
+    if obj.contains_key("parents") {
+        return normalize_parent_digests_from_value(obj.get("parents"));
+    }
+    if let Some(prev) = obj.get("previous_digest").and_then(|v| v.as_str()) {
+        return normalize_parent_digests_from_value(Some(&Value::Array(vec![Value::String(
+            prev.to_string(),
+        )])));
+    }
+    vec![]
+}
+
+#[derive(Debug, Clone)]
+pub struct CoreSharedObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+}
+
+impl CoreSharedObject {
+    pub fn new(
+        persistent: bool,
+        storage_mode: &str,
+        storage_backend: Option<SharedKvBackend>,
+        enable_memory_cache: bool,
+        memory_cache_size: usize,
+    ) -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(
+                persistent,
+                StorageMode::from_str(storage_mode),
+                storage_backend,
+                enable_memory_cache,
+                memory_cache_size,
+            ),
+        }
+    }
+
+    pub fn compute_digest(data: &Value) -> String {
+        compute_digest_value(data)
+    }
+}
+
+impl Default for CoreSharedObject {
+    fn default() -> Self {
+        Self::new(false, "memory", None, true, 1024)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NonMerkelizedObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+}
+
+impl NonMerkelizedObject {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+        }
+    }
+}
+
+impl Default for NonMerkelizedObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for NonMerkelizedObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "NonMerkelizedObject"
+    }
+
+    async fn is_valid(&self, _message: &SharedMessage) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_message(&mut self, _message: SharedMessage) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"merkleized": false}))
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MerkelizedObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+}
+
+impl MerkelizedObject {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+        }
+    }
+}
+
+impl Default for MerkelizedObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for MerkelizedObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "MerkelizedObject"
+    }
+
+    async fn is_valid(&self, _message: &SharedMessage) -> Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message, digest, parents)
+            .await;
+        Ok(())
+    }
+
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({
+            "digests": self.state.digests.len(),
+            "messages": self.state.messages.len(),
+            "head_digests": self.state.head_digest_list(),
+        }))
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+pub type MerkleizedObject = MerkelizedObject;
+pub type NativeSharedObject = CoreSharedObject;
+
+#[derive(Debug, Clone)]
+pub struct UTXOLedger {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub utxos: HashMap<String, Value>,
+}
+
+impl UTXOLedger {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            utxos: HashMap::new(),
+        }
+    }
+}
+
+impl Default for UTXOLedger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for UTXOLedger {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "UTXOLedger"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        match data.get("action").and_then(|v| v.as_str()) {
+            Some("utxo_add") => Ok(data.contains_key("utxo_id")
+                && data.contains_key("amount")
+                && data.contains_key("owner")),
+            Some("utxo_spend") => Ok(data
+                .get("utxo_id")
+                .and_then(|v| v.as_str())
+                .map(|id| self.utxos.contains_key(id))
+                .unwrap_or(false)),
+            _ => Ok(false),
+        }
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest, parents)
+            .await;
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let action = data
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if action == "utxo_add" {
+            if let Some(utxo_id) = data.get("utxo_id").and_then(|v| v.as_str()) {
+                let entry = json!({
+                    "amount": data.get("amount").cloned().unwrap_or(Value::Null),
+                    "owner": data.get("owner").cloned().unwrap_or(Value::Null),
+                    "meta": data.get("meta").cloned().unwrap_or_else(|| json!({})),
+                });
+                self.utxos.insert(utxo_id.to_string(), entry.clone());
+                self.storage.write(&format!("utxo:{utxo_id}"), entry).await;
+            }
+        } else if action == "utxo_spend" {
+            if let Some(utxo_id) = data.get("utxo_id").and_then(|v| v.as_str()) {
+                self.utxos.remove(utxo_id);
+                self.storage.delete(&format!("utxo:{utxo_id}")).await;
+            }
+        }
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"utxo_count": self.utxos.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.utxos.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BalanceLedger {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub balances: HashMap<String, f64>,
+}
+
+impl BalanceLedger {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            balances: HashMap::new(),
+        }
+    }
+}
+
+impl Default for BalanceLedger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for BalanceLedger {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "BalanceLedger"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        let action = data
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let amount = data.get("amount").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        match action {
+            "credit" => Ok(data.contains_key("account") && data.get("amount").is_some()),
+            "debit" => {
+                let Some(account) = data.get("account").and_then(|v| v.as_str()) else {
+                    return Ok(false);
+                };
+                Ok(self.balances.get(account).cloned().unwrap_or(0.0) >= amount)
+            },
+            "transfer" => {
+                let Some(src) = data.get("from").and_then(|v| v.as_str()) else {
+                    return Ok(false);
+                };
+                let has_dst = data.get("to").and_then(|v| v.as_str()).is_some();
+                Ok(has_dst && self.balances.get(src).cloned().unwrap_or(0.0) >= amount)
+            },
+            _ => Ok(false),
+        }
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest, parents)
+            .await;
+
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let action = data
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let amount = data.get("amount").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        match action {
+            "credit" => {
+                if let Some(account) = data.get("account").and_then(|v| v.as_str()) {
+                    let entry = self.balances.get(account).cloned().unwrap_or(0.0) + amount;
+                    self.balances.insert(account.to_string(), entry);
+                    self.storage
+                        .write(&format!("balance:{account}"), json!(entry))
+                        .await;
+                }
+            },
+            "debit" => {
+                if let Some(account) = data.get("account").and_then(|v| v.as_str()) {
+                    let entry = self.balances.get(account).cloned().unwrap_or(0.0) - amount;
+                    self.balances.insert(account.to_string(), entry);
+                    self.storage
+                        .write(&format!("balance:{account}"), json!(entry))
+                        .await;
+                }
+            },
+            "transfer" => {
+                if let (Some(src), Some(dst)) = (
+                    data.get("from").and_then(|v| v.as_str()),
+                    data.get("to").and_then(|v| v.as_str()),
+                ) {
+                    let src_entry = self.balances.get(src).cloned().unwrap_or(0.0) - amount;
+                    let dst_entry = self.balances.get(dst).cloned().unwrap_or(0.0) + amount;
+                    self.balances.insert(src.to_string(), src_entry);
+                    self.balances.insert(dst.to_string(), dst_entry);
+                    self.storage
+                        .write(&format!("balance:{src}"), json!(src_entry))
+                        .await;
+                    self.storage
+                        .write(&format!("balance:{dst}"), json!(dst_entry))
+                        .await;
+                }
+            },
+            _ => {},
+        }
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"balance_count": self.balances.len(), "balances": self.balances}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.balances.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Blockchain {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub blocks: Vec<Value>,
+}
+
+impl Blockchain {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            blocks: Vec::new(),
+        }
+    }
+}
+
+impl Default for Blockchain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for Blockchain {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "Blockchain"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        let prev = data
+            .get("previous_digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if self.blocks.is_empty() {
+            return Ok(prev.is_empty() || prev == "genesis");
+        }
+        let last = self
+            .blocks
+            .last()
+            .and_then(|b| b.get("digest"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        Ok(prev == last)
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest.clone(), parents)
+            .await;
+        let block = json!({
+            "digest": digest,
+            "payload": message.data
+        });
+        self.blocks.push(block.clone());
+        let key = block
+            .get("digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        self.storage.write(&format!("block:{key}"), block).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"block_count": self.blocks.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.blocks.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DAGObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub nodes: HashMap<String, Value>,
+    frontier_state_index: HashMap<String, isize>,
+    pub frontier_digest_version: u32,
+}
+
+impl DAGObject {
+    pub fn new() -> Self {
+        let mut frontier_state_index = HashMap::new();
+        frontier_state_index.insert(String::new(), -1);
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            nodes: HashMap::new(),
+            frontier_state_index,
+            frontier_digest_version: 1,
+        }
+    }
+
+    pub fn get_head_digests(&self) -> Vec<String> {
+        self.state.head_digest_list()
+    }
+
+    fn current_frontier_digest(&self) -> String {
+        let heads = self.get_head_digests();
+        if heads.is_empty() {
+            return String::new();
+        }
+        compute_digest_value(&json!({
+            "v": self.frontier_digest_version,
+            "frontier_heads": heads
+        }))
+    }
+}
+
+impl Default for DAGObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for DAGObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "DAGObject"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let Some(data) = message.data.as_object() else {
+            return Ok(false);
+        };
+        let parents = normalize_parent_digests_from_value(data.get("parents"));
+        if !parents.iter().all(|p| self.nodes.contains_key(p)) {
+            return Ok(false);
+        }
+        if !parents.is_empty() {
+            let head_set: HashSet<String> = self.state.head_digest_list().into_iter().collect();
+            if !parents.iter().all(|p| head_set.contains(p)) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest.clone(), parents.clone())
+            .await;
+        let node = json!({"digest": digest, "parents": parents, "data": message.data});
+        let digest_key = node
+            .get("digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        self.nodes.insert(digest_key.clone(), node.clone());
+        self.storage.write(&format!("dag:{digest_key}"), node).await;
+        let frontier = self.current_frontier_digest();
+        self.frontier_state_index
+            .insert(frontier, (self.state.messages.len() as isize) - 1);
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.current_frontier_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest) || self.frontier_state_index.contains_key(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        self.has_digest(digest).await
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        self.get_messages_since_digest(digest.unwrap_or_default())
+            .await
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        if self.state.messages.is_empty() {
+            return Ok(vec![]);
+        }
+        if digest.is_empty() {
+            return Ok(self.state.messages.clone());
+        }
+        if let Some(idx) = self.state.digest_index.get(digest) {
+            return Ok(self.state.messages[(*idx + 1)..].to_vec());
+        }
+        if let Some(idx) = self.frontier_state_index.get(digest) {
+            let start = (*idx + 1).max(0) as usize;
+            return Ok(self.state.messages[start..].to_vec());
+        }
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"node_count": self.nodes.len(), "heads": self.get_head_digests()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.nodes.clear();
+        self.frontier_state_index.clear();
+        self.frontier_state_index.insert(String::new(), -1);
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionChain {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    state: MerkelizedState,
+    pub transactions: Vec<Value>,
+}
+
+impl TransactionChain {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            state: MerkelizedState::new(),
+            transactions: Vec::new(),
+        }
+    }
+}
+
+impl Default for TransactionChain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for TransactionChain {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "TransactionChain"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let digest = compute_digest_value(&message.data);
+        if self.state.contains_digest(&digest) {
+            return Ok(());
+        }
+        let parents = extract_parent_digests(&message.data);
+        self.state
+            .record_message(&mut self.storage, message.clone(), digest.clone(), parents)
+            .await;
+        let tx = json!({"tx_digest": digest, "payload": message.data});
+        self.transactions.push(tx.clone());
+        let key = tx
+            .get("tx_digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        self.storage.write(&format!("tx:{key}"), tx).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.state.latest_digest())
+    }
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.state.contains_digest(digest))
+    }
+    async fn add_digest(&mut self, digest: String) -> Result<bool> {
+        if self.state.contains_digest(&digest) {
+            return Ok(false);
+        }
+        self.state
+            .digest_index
+            .insert(digest.clone(), self.state.digests.len());
+        self.state.digests.push(digest);
+        Ok(true)
+    }
+    async fn gossip_messages(&self, digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest.unwrap_or_default()))
+    }
+    async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(self.state.messages_since_digest(digest))
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"transaction_count": self.transactions.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.state = MerkelizedState::new();
+        self.transactions.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheObject {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    pub cache: HashMap<String, Value>,
+}
+
+impl CacheObject {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            cache: HashMap::new(),
+        }
+    }
+}
+
+impl Default for CacheObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for CacheObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "CacheObject"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let key = data
+            .get("key")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| compute_digest_value(&message.data));
+
+        if data.get("action").and_then(|v| v.as_str()) == Some("delete") {
+            self.cache.remove(&key);
+            self.storage.delete(&key).await;
+            return Ok(());
+        }
+
+        let value = data.get("value").cloned().unwrap_or(message.data);
+        self.cache.insert(key.clone(), value.clone());
+        self.storage.write(&key, value).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"cache_size": self.cache.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.cache.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Mempool {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    pub cache: HashMap<String, Value>,
+    pub transactions: HashMap<String, Value>,
+}
+
+impl Mempool {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            cache: HashMap::new(),
+            transactions: HashMap::new(),
+        }
+    }
+}
+
+impl Default for Mempool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for Mempool {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "Mempool"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let tx = message.data.as_object().cloned().unwrap_or_default();
+        let tx_id = tx
+            .get("tx_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| compute_digest_value(&message.data));
+
+        if tx.get("action").and_then(|v| v.as_str()) == Some("remove") {
+            self.transactions.remove(&tx_id);
+            self.cache.remove(&tx_id);
+            self.storage.delete(&format!("mempool:{tx_id}")).await;
+            return Ok(());
+        }
+        let as_value = Value::Object(tx);
+        self.transactions.insert(tx_id.clone(), as_value.clone());
+        self.cache.insert(tx_id.clone(), as_value.clone());
+        self.storage
+            .write(&format!("mempool:{tx_id}"), as_value)
+            .await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"tx_count": self.transactions.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.cache.clear();
+        self.transactions.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DocumentCache {
+    id: SharedObjectId,
+    storage: CoreStorage,
+    pub cache: HashMap<String, Value>,
+    pub documents: HashMap<String, Value>,
+}
+
+impl DocumentCache {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            storage: CoreStorage::new(false, StorageMode::Memory, None, true, 1024),
+            cache: HashMap::new(),
+            documents: HashMap::new(),
+        }
+    }
+}
+
+impl Default for DocumentCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for DocumentCache {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "DocumentCache"
+    }
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        Ok(message.data.is_object())
+    }
+    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+        let data = message.data.as_object().cloned().unwrap_or_default();
+        let doc_id = data
+            .get("doc_id")
+            .or_else(|| data.get("document_id"))
+            .or_else(|| data.get("key"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| compute_digest_value(&message.data));
+
+        if data.get("action").and_then(|v| v.as_str()) == Some("delete") {
+            self.documents.remove(&doc_id);
+            self.cache.remove(&doc_id);
+            self.storage.delete(&format!("doc:{doc_id}")).await;
+            return Ok(());
+        }
+
+        let payload = data
+            .get("document")
+            .cloned()
+            .or_else(|| data.get("value").cloned())
+            .unwrap_or(Value::Object(data));
+        self.documents.insert(doc_id.clone(), payload.clone());
+        self.cache.insert(doc_id.clone(), payload.clone());
+        self.storage.write(&format!("doc:{doc_id}"), payload).await;
+        Ok(())
+    }
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(String::new())
+    }
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> Result<Value> {
+        Ok(json!({"document_count": self.documents.len()}))
+    }
+    async fn reset(&mut self) -> Result<()> {
+        self.cache.clear();
+        self.documents.clear();
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/src/examples/chatroom.rs
+++ b/src/examples/chatroom.rs
@@ -14,8 +14,11 @@ use crate::{
         KeyType, PrivateKey, PublicKey, Signature,
     },
     error::{ChaincraftError, Result},
+    network::PeerId,
     shared::{MessageType, SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    storage::MemoryStorage,
+    ChaincraftNode,
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -23,6 +26,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::any::Any;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Chatroom message types
@@ -490,6 +494,76 @@ impl ApplicationObject for ChatroomObject {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
+    }
+}
+
+/// Typed node wrapper for Chatroom examples.
+pub struct ChatroomNode {
+    node: ChaincraftNode,
+    object_id: SharedObjectId,
+}
+
+impl ChatroomNode {
+    pub async fn new(port: u16) -> Result<Self> {
+        let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
+        node.set_port(port);
+        let object_id = node
+            .add_shared_object(Box::new(ChatroomObject::new()))
+            .await?;
+        Ok(Self { node, object_id })
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        self.node.start().await
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        self.node.close().await
+    }
+
+    pub async fn connect_to_peer(&mut self, addr: &str) -> Result<()> {
+        self.node.connect_to_peer(addr).await
+    }
+
+    pub fn host(&self) -> &str {
+        self.node.host()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.node.port()
+    }
+
+    pub fn id(&self) -> &crate::network::PeerId {
+        self.node.id()
+    }
+
+    pub async fn publish(&mut self, data: Value) -> Result<String> {
+        self.node.create_shared_message_with_data(data).await
+    }
+
+    pub async fn chatroom_message_count(&self, room: &str) -> Result<usize> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(ChaincraftError::validation("ChatroomObject not found"));
+        };
+        let Some(chatroom) = obj.as_any().downcast_ref::<ChatroomObject>() else {
+            return Err(ChaincraftError::validation("Object type mismatch for ChatroomObject"));
+        };
+        Ok(chatroom
+            .get_chatroom(room)
+            .map(|r| r.messages.len())
+            .unwrap_or(0))
+    }
+
+    pub async fn chatroom_names(&self) -> Result<Vec<String>> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(ChaincraftError::validation("ChatroomObject not found"));
+        };
+        let Some(chatroom) = obj.as_any().downcast_ref::<ChatroomObject>() else {
+            return Err(ChaincraftError::validation("Object type mismatch for ChatroomObject"));
+        };
+        Ok(chatroom.get_chatrooms().keys().cloned().collect())
     }
 }
 

--- a/src/examples/ecdsa_ledger.rs
+++ b/src/examples/ecdsa_ledger.rs
@@ -6,14 +6,18 @@
 use crate::{
     crypto::ecdsa::{ECDSASignature, ECDSAVerifier},
     error::{ChaincraftError, Result},
+    network::PeerId,
     shared::{SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    storage::MemoryStorage,
+    ChaincraftNode,
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "message_type")]
@@ -246,6 +250,69 @@ impl ApplicationObject for ECDSALedgerObject {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
+    }
+}
+
+/// Typed node wrapper for ECDSA ledger examples.
+pub struct ECDSALedgerNode {
+    node: ChaincraftNode,
+    object_id: SharedObjectId,
+}
+
+impl ECDSALedgerNode {
+    pub async fn new(port: u16) -> Result<Self> {
+        let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
+        node.set_port(port);
+        let object_id = node
+            .add_shared_object(Box::new(ECDSALedgerObject::new()))
+            .await?;
+        Ok(Self { node, object_id })
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        self.node.start().await
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        self.node.close().await
+    }
+
+    pub async fn connect_to_peer(&mut self, addr: &str) -> Result<()> {
+        self.node.connect_to_peer(addr).await
+    }
+
+    pub fn host(&self) -> &str {
+        self.node.host()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.node.port()
+    }
+
+    pub async fn publish(&mut self, data: serde_json::Value) -> Result<String> {
+        self.node.create_shared_message_with_data(data).await
+    }
+
+    pub async fn entry_count(&self) -> Result<usize> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(ChaincraftError::validation("ECDSALedgerObject not found"));
+        };
+        let Some(ledger) = obj.as_any().downcast_ref::<ECDSALedgerObject>() else {
+            return Err(ChaincraftError::validation("Object type mismatch for ECDSALedgerObject"));
+        };
+        Ok(ledger.entries().len())
+    }
+
+    pub async fn balance(&self, account: &str) -> Result<u64> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(ChaincraftError::validation("ECDSALedgerObject not found"));
+        };
+        let Some(ledger) = obj.as_any().downcast_ref::<ECDSALedgerObject>() else {
+            return Err(ChaincraftError::validation("Object type mismatch for ECDSALedgerObject"));
+        };
+        Ok(ledger.balance(account))
     }
 }
 

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -2,4 +2,6 @@ pub mod chatroom;
 pub mod ecdsa_ledger;
 pub mod randomness_beacon;
 pub mod slush;
+pub mod snowball;
+pub mod snowflake;
 pub mod tendermint;

--- a/src/examples/randomness_beacon.rs
+++ b/src/examples/randomness_beacon.rs
@@ -4,14 +4,18 @@ use crate::{
         KeyType, PrivateKey, PublicKey, Signature,
     },
     error::{ChaincraftError, Result},
+    network::PeerId,
     shared::{MessageType, SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    storage::MemoryStorage,
+    ChaincraftNode,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// Randomness beacon message types
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -572,6 +576,67 @@ impl ApplicationObject for RandomnessBeaconObject {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+}
+
+/// Typed node wrapper for Randomness Beacon examples.
+pub struct RandomnessBeaconNode {
+    node: ChaincraftNode,
+    object_id: SharedObjectId,
+}
+
+impl RandomnessBeaconNode {
+    pub async fn new(port: u16, round_duration_secs: u64, threshold: u64) -> Result<Self> {
+        let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
+        node.set_port(port);
+        let beacon = RandomnessBeaconObject::new(round_duration_secs, threshold)?;
+        let object_id = node.add_shared_object(Box::new(beacon)).await?;
+        Ok(Self { node, object_id })
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        self.node.start().await
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        self.node.close().await
+    }
+
+    pub async fn connect_to_peer(&mut self, addr: &str) -> Result<()> {
+        self.node.connect_to_peer(addr).await
+    }
+
+    pub fn host(&self) -> &str {
+        self.node.host()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.node.port()
+    }
+
+    pub async fn publish(&mut self, data: serde_json::Value) -> Result<String> {
+        self.node.create_shared_message_with_data(data).await
+    }
+
+    pub async fn validator_address(&self) -> Result<String> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(ChaincraftError::validation("RandomnessBeaconObject not found"));
+        };
+        let Some(beacon) = obj.as_any().downcast_ref::<RandomnessBeaconObject>() else {
+            return Err(ChaincraftError::validation(
+                "Object type mismatch for RandomnessBeaconObject",
+            ));
+        };
+        Ok(beacon.my_validator_address.clone())
+    }
+
+    pub async fn beacon_state(&self) -> Result<serde_json::Value> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(ChaincraftError::validation("RandomnessBeaconObject not found"));
+        };
+        obj.get_state().await
     }
 }
 

--- a/src/examples/snowball.rs
+++ b/src/examples/snowball.rs
@@ -1,16 +1,12 @@
-//! Slush Protocol - Avalanche paper Section 2.2
+//! Snowball Protocol - Avalanche family
 //!
-//! A toy single-decree consensus protocol (NOT Byzantine fault tolerant).
-//! Nodes converge on a binary choice (Red or Blue) via repeated random
-//! sampling: each round, a node broadcasts its color, collects peer colors
-//! from incoming messages, and flips to the majority when >= alpha*k agree.
-//!
-//! Implements `ApplicationObject` so it integrates with ChaincraftNode gossip.
+//! Extends Snowflake by keeping confidence counters per color plus
+//! a consecutive-success counter for fast finalization.
 
 use crate::{
     error::Result,
     network::PeerId,
-    shared::{MessageType, SharedMessage, SharedObjectId},
+    shared::{SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
     storage::MemoryStorage,
     ChaincraftNode,
@@ -22,7 +18,6 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-/// Binary color choice (paper uses R/B).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Color {
     Red,
@@ -38,52 +33,52 @@ impl std::fmt::Display for Color {
     }
 }
 
-/// A Slush vote message broadcast by a node during a round.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SlushVote {
+pub struct SnowballVote {
     pub message_type: String,
     pub node_id: String,
     pub round: u32,
     pub color: Color,
 }
 
-/// Slush consensus state, implements ApplicationObject.
 #[derive(Debug, Clone)]
-pub struct SlushObject {
+pub struct SnowballObject {
     id: SharedObjectId,
     pub node_id: String,
-    pub color: Option<Color>,
+    pub preference: Option<Color>,
     pub accepted: Option<Color>,
     pub k: usize,
     pub alpha: f64,
-    pub m: u32,
+    pub beta: u32,
     pub current_round: u32,
-    votes: Vec<SlushVote>,
+    pub confidence_red: u32,
+    pub confidence_blue: u32,
+    pub last_color: Option<Color>,
+    pub consecutive_count: u32,
+    votes: Vec<SnowballVote>,
     seen_hashes: HashSet<String>,
 }
 
-impl SlushObject {
-    pub fn new(node_id: String, k: usize, alpha: f64, m: u32) -> Self {
+impl SnowballObject {
+    pub fn new(node_id: String, k: usize, alpha: f64, beta: u32) -> Self {
         Self {
             id: SharedObjectId::new(),
             node_id,
-            color: None,
+            preference: None,
             accepted: None,
             k,
             alpha,
-            m,
+            beta,
             current_round: 0,
+            confidence_red: 0,
+            confidence_blue: 0,
+            last_color: None,
+            consecutive_count: 0,
             votes: Vec::new(),
             seen_hashes: HashSet::new(),
         }
     }
 
-    /// Get all collected votes.
-    pub fn votes(&self) -> &[SlushVote] {
-        &self.votes
-    }
-
-    /// Count votes for a given round.
     pub fn count_votes_for_round(&self, round: u32) -> (usize, usize) {
         let mut red = 0usize;
         let mut blue = 0usize;
@@ -98,53 +93,82 @@ impl SlushObject {
         (red, blue)
     }
 
-    /// Process one round of Slush given collected votes. Returns whether color flipped.
     pub fn process_round(&mut self, round: u32) -> bool {
         let (red, blue) = self.count_votes_for_round(round);
-        let threshold = (self.alpha * self.k as f64) as usize;
-        let current = match self.color {
-            Some(c) => c,
-            None => return false,
-        };
-        if red >= threshold && current != Color::Red {
-            self.color = Some(Color::Red);
-            return true;
-        }
-        if blue >= threshold && current != Color::Blue {
-            self.color = Some(Color::Blue);
-            return true;
-        }
-        false
-    }
+        let threshold = ((self.alpha * self.k as f64) as usize).max(1);
 
-    /// Finalize: set accepted = current color.
-    pub fn finalize(&mut self) {
-        self.accepted = self.color;
+        let sample_majority = if red >= threshold && red > blue {
+            Some(Color::Red)
+        } else if blue >= threshold && blue > red {
+            Some(Color::Blue)
+        } else {
+            None
+        };
+
+        let Some(majority) = sample_majority else {
+            return false;
+        };
+
+        match majority {
+            Color::Red => self.confidence_red += 1,
+            Color::Blue => self.confidence_blue += 1,
+        }
+
+        let mut flipped = false;
+        if self.preference.is_none() {
+            self.preference = Some(majority);
+        } else if let Some(pref) = self.preference {
+            let pref_conf = match pref {
+                Color::Red => self.confidence_red,
+                Color::Blue => self.confidence_blue,
+            };
+            let maj_conf = match majority {
+                Color::Red => self.confidence_red,
+                Color::Blue => self.confidence_blue,
+            };
+            if maj_conf > pref_conf {
+                self.preference = Some(majority);
+                flipped = pref != majority;
+            }
+        }
+
+        match self.last_color {
+            Some(last) if last == majority => self.consecutive_count += 1,
+            _ => {
+                self.last_color = Some(majority);
+                self.consecutive_count = 1;
+            },
+        }
+
+        if self.consecutive_count > self.beta {
+            self.accepted = self.preference.or(Some(majority));
+        }
+
+        flipped
     }
 }
 
-/// Create a SlushVote JSON value suitable for `node.create_shared_message_with_data`.
 pub fn create_vote_message(node_id: &str, round: u32, color: Color) -> Value {
     serde_json::json!({
-        "message_type": "SLUSH_VOTE",
+        "message_type": "SNOWBALL_VOTE",
         "node_id": node_id,
         "round": round,
         "color": color,
     })
 }
 
-/// Typed node wrapper for Slush examples.
-pub struct SlushNode {
+/// Typed node wrapper for Snowball examples.
+pub struct SnowballNode {
     node: ChaincraftNode,
     object_id: SharedObjectId,
 }
 
-impl SlushNode {
-    pub async fn new(node_id: String, port: u16, k: usize, alpha: f64, m: u32) -> Result<Self> {
+impl SnowballNode {
+    pub async fn new(node_id: String, port: u16, k: usize, alpha: f64, beta: u32) -> Result<Self> {
         let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
         node.set_port(port);
         let object_id = node
-            .add_shared_object(Box::new(SlushObject::new(node_id, k, alpha, m)))
+            .add_shared_object(Box::new(SnowballObject::new(node_id, k, alpha, beta)))
             .await?;
         Ok(Self { node, object_id })
     }
@@ -178,73 +202,92 @@ impl SlushNode {
     pub async fn node_id(&self) -> Result<String> {
         let registry = self.node.app_objects.read().await;
         let Some(obj) = registry.get(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+            return Err(crate::error::ChaincraftError::validation("SnowballObject not found"));
         };
-        let Some(slush) = obj.as_any().downcast_ref::<SlushObject>() else {
+        let Some(snowball) = obj.as_any().downcast_ref::<SnowballObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowballObject",
             ));
         };
-        Ok(slush.node_id.clone())
+        Ok(snowball.node_id.clone())
     }
 
-    pub async fn color(&self) -> Result<Option<Color>> {
+    pub async fn preference(&self) -> Result<Option<Color>> {
         let registry = self.node.app_objects.read().await;
         let Some(obj) = registry.get(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+            return Err(crate::error::ChaincraftError::validation("SnowballObject not found"));
         };
-        let Some(slush) = obj.as_any().downcast_ref::<SlushObject>() else {
+        let Some(snowball) = obj.as_any().downcast_ref::<SnowballObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowballObject",
             ));
         };
-        Ok(slush.color)
+        Ok(snowball.preference)
+    }
+
+    pub async fn accepted(&self) -> Result<Option<Color>> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(crate::error::ChaincraftError::validation("SnowballObject not found"));
+        };
+        let Some(snowball) = obj.as_any().downcast_ref::<SnowballObject>() else {
+            return Err(crate::error::ChaincraftError::validation(
+                "Object type mismatch for SnowballObject",
+            ));
+        };
+        Ok(snowball.accepted)
     }
 
     pub async fn process_round(&mut self, round: u32) -> Result<bool> {
         let mut registry = self.node.app_objects.write().await;
         let Some(obj) = registry.objects.get_mut(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+            return Err(crate::error::ChaincraftError::validation("SnowballObject not found"));
         };
-        let Some(slush) = obj.as_any_mut().downcast_mut::<SlushObject>() else {
+        let Some(snowball) = obj.as_any_mut().downcast_mut::<SnowballObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowballObject",
             ));
         };
-        let flipped = slush.process_round(round);
-        slush.current_round = round;
+        let flipped = snowball.process_round(round);
+        snowball.current_round = round;
         Ok(flipped)
     }
 
-    pub async fn finalize(&mut self) -> Result<Option<Color>> {
-        let mut registry = self.node.app_objects.write().await;
-        let Some(obj) = registry.objects.get_mut(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+    pub async fn state_snapshot(&self) -> Result<(Option<Color>, Option<Color>, u32, u32, u32)> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(crate::error::ChaincraftError::validation("SnowballObject not found"));
         };
-        let Some(slush) = obj.as_any_mut().downcast_mut::<SlushObject>() else {
+        let Some(snowball) = obj.as_any().downcast_ref::<SnowballObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowballObject",
             ));
         };
-        slush.finalize();
-        Ok(slush.accepted)
+        Ok((
+            snowball.preference,
+            snowball.accepted,
+            snowball.confidence_red,
+            snowball.confidence_blue,
+            snowball.consecutive_count,
+        ))
     }
 }
 
 #[async_trait]
-impl ApplicationObject for SlushObject {
+impl ApplicationObject for SnowballObject {
     fn id(&self) -> &SharedObjectId {
         &self.id
     }
 
     fn type_name(&self) -> &'static str {
-        "SlushObject"
+        "SnowballObject"
     }
 
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
-        let vote: std::result::Result<SlushVote, _> = serde_json::from_value(message.data.clone());
+        let vote: std::result::Result<SnowballVote, _> =
+            serde_json::from_value(message.data.clone());
         if let Ok(v) = vote {
-            return Ok(v.message_type == "SLUSH_VOTE");
+            return Ok(v.message_type == "SNOWBALL_VOTE");
         }
         Ok(false)
     }
@@ -255,13 +298,14 @@ impl ApplicationObject for SlushObject {
         }
         self.seen_hashes.insert(message.hash.clone());
 
-        let vote: SlushVote = match serde_json::from_value(message.data.clone()) {
+        let vote: SnowballVote = match serde_json::from_value(message.data.clone()) {
             Ok(v) => v,
             Err(_) => return Ok(()),
         };
 
-        if self.color.is_none() {
-            self.color = Some(vote.color);
+        if self.preference.is_none() {
+            self.preference = Some(vote.color);
+            self.last_color = Some(vote.color);
         }
 
         self.votes.push(vote);
@@ -273,7 +317,7 @@ impl ApplicationObject for SlushObject {
     }
 
     async fn get_latest_digest(&self) -> Result<String> {
-        Ok(format!("{:?}", self.color))
+        Ok(format!("{:?}", self.accepted.or(self.preference)))
     }
 
     async fn has_digest(&self, _digest: &str) -> Result<bool> {
@@ -299,17 +343,24 @@ impl ApplicationObject for SlushObject {
     async fn get_state(&self) -> Result<Value> {
         Ok(serde_json::json!({
             "node_id": self.node_id,
-            "color": format!("{:?}", self.color),
+            "preference": format!("{:?}", self.preference),
             "accepted": format!("{:?}", self.accepted),
             "round": self.current_round,
+            "confidence_red": self.confidence_red,
+            "confidence_blue": self.confidence_blue,
+            "consecutive_count": self.consecutive_count,
             "votes": self.votes.len(),
         }))
     }
 
     async fn reset(&mut self) -> Result<()> {
-        self.color = None;
+        self.preference = None;
         self.accepted = None;
         self.current_round = 0;
+        self.confidence_red = 0;
+        self.confidence_blue = 0;
+        self.last_color = None;
+        self.consecutive_count = 0;
         self.votes.clear();
         self.seen_hashes.clear();
         Ok(())

--- a/src/examples/snowflake.rs
+++ b/src/examples/snowflake.rs
@@ -1,16 +1,12 @@
-//! Slush Protocol - Avalanche paper Section 2.2
+//! Snowflake Protocol - Avalanche paper Section 2.3
 //!
-//! A toy single-decree consensus protocol (NOT Byzantine fault tolerant).
-//! Nodes converge on a binary choice (Red or Blue) via repeated random
-//! sampling: each round, a node broadcasts its color, collects peer colors
-//! from incoming messages, and flips to the majority when >= alpha*k agree.
-//!
-//! Implements `ApplicationObject` so it integrates with ChaincraftNode gossip.
+//! BFT single-decree consensus with a consecutive-success counter.
+//! This object uses Chaincraft gossip messages for vote exchange.
 
 use crate::{
     error::Result,
     network::PeerId,
-    shared::{MessageType, SharedMessage, SharedObjectId},
+    shared::{SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
     storage::MemoryStorage,
     ChaincraftNode,
@@ -22,7 +18,6 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-/// Binary color choice (paper uses R/B).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Color {
     Red,
@@ -38,32 +33,31 @@ impl std::fmt::Display for Color {
     }
 }
 
-/// A Slush vote message broadcast by a node during a round.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SlushVote {
+pub struct SnowflakeVote {
     pub message_type: String,
     pub node_id: String,
     pub round: u32,
     pub color: Color,
 }
 
-/// Slush consensus state, implements ApplicationObject.
 #[derive(Debug, Clone)]
-pub struct SlushObject {
+pub struct SnowflakeObject {
     id: SharedObjectId,
     pub node_id: String,
     pub color: Option<Color>,
     pub accepted: Option<Color>,
     pub k: usize,
     pub alpha: f64,
-    pub m: u32,
+    pub beta: u32,
     pub current_round: u32,
-    votes: Vec<SlushVote>,
+    pub consecutive_count: u32,
+    votes: Vec<SnowflakeVote>,
     seen_hashes: HashSet<String>,
 }
 
-impl SlushObject {
-    pub fn new(node_id: String, k: usize, alpha: f64, m: u32) -> Self {
+impl SnowflakeObject {
+    pub fn new(node_id: String, k: usize, alpha: f64, beta: u32) -> Self {
         Self {
             id: SharedObjectId::new(),
             node_id,
@@ -71,19 +65,14 @@ impl SlushObject {
             accepted: None,
             k,
             alpha,
-            m,
+            beta,
             current_round: 0,
+            consecutive_count: 0,
             votes: Vec::new(),
             seen_hashes: HashSet::new(),
         }
     }
 
-    /// Get all collected votes.
-    pub fn votes(&self) -> &[SlushVote] {
-        &self.votes
-    }
-
-    /// Count votes for a given round.
     pub fn count_votes_for_round(&self, round: u32) -> (usize, usize) {
         let mut red = 0usize;
         let mut blue = 0usize;
@@ -98,53 +87,68 @@ impl SlushObject {
         (red, blue)
     }
 
-    /// Process one round of Slush given collected votes. Returns whether color flipped.
     pub fn process_round(&mut self, round: u32) -> bool {
         let (red, blue) = self.count_votes_for_round(round);
-        let threshold = (self.alpha * self.k as f64) as usize;
-        let current = match self.color {
-            Some(c) => c,
-            None => return false,
-        };
-        if red >= threshold && current != Color::Red {
-            self.color = Some(Color::Red);
-            return true;
-        }
-        if blue >= threshold && current != Color::Blue {
-            self.color = Some(Color::Blue);
-            return true;
-        }
-        false
-    }
+        let threshold = ((self.alpha * self.k as f64) as usize).max(1);
 
-    /// Finalize: set accepted = current color.
-    pub fn finalize(&mut self) {
-        self.accepted = self.color;
+        let sampled_majority = if red >= threshold && red > blue {
+            Some(Color::Red)
+        } else if blue >= threshold && blue > red {
+            Some(Color::Blue)
+        } else {
+            None
+        };
+
+        let Some(majority) = sampled_majority else {
+            return false;
+        };
+
+        let flipped = match self.color {
+            Some(current) if current != majority => {
+                self.color = Some(majority);
+                self.consecutive_count = 1;
+                true
+            },
+            Some(_) => {
+                self.consecutive_count += 1;
+                false
+            },
+            None => {
+                self.color = Some(majority);
+                self.consecutive_count = 1;
+                false
+            },
+        };
+
+        if self.consecutive_count > self.beta {
+            self.accepted = self.color;
+        }
+
+        flipped
     }
 }
 
-/// Create a SlushVote JSON value suitable for `node.create_shared_message_with_data`.
 pub fn create_vote_message(node_id: &str, round: u32, color: Color) -> Value {
     serde_json::json!({
-        "message_type": "SLUSH_VOTE",
+        "message_type": "SNOWFLAKE_VOTE",
         "node_id": node_id,
         "round": round,
         "color": color,
     })
 }
 
-/// Typed node wrapper for Slush examples.
-pub struct SlushNode {
+/// Typed node wrapper for Snowflake examples.
+pub struct SnowflakeNode {
     node: ChaincraftNode,
     object_id: SharedObjectId,
 }
 
-impl SlushNode {
-    pub async fn new(node_id: String, port: u16, k: usize, alpha: f64, m: u32) -> Result<Self> {
+impl SnowflakeNode {
+    pub async fn new(node_id: String, port: u16, k: usize, alpha: f64, beta: u32) -> Result<Self> {
         let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
         node.set_port(port);
         let object_id = node
-            .add_shared_object(Box::new(SlushObject::new(node_id, k, alpha, m)))
+            .add_shared_object(Box::new(SnowflakeObject::new(node_id, k, alpha, beta)))
             .await?;
         Ok(Self { node, object_id })
     }
@@ -178,73 +182,86 @@ impl SlushNode {
     pub async fn node_id(&self) -> Result<String> {
         let registry = self.node.app_objects.read().await;
         let Some(obj) = registry.get(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+            return Err(crate::error::ChaincraftError::validation("SnowflakeObject not found"));
         };
-        let Some(slush) = obj.as_any().downcast_ref::<SlushObject>() else {
+        let Some(snowflake) = obj.as_any().downcast_ref::<SnowflakeObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowflakeObject",
             ));
         };
-        Ok(slush.node_id.clone())
+        Ok(snowflake.node_id.clone())
     }
 
     pub async fn color(&self) -> Result<Option<Color>> {
         let registry = self.node.app_objects.read().await;
         let Some(obj) = registry.get(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+            return Err(crate::error::ChaincraftError::validation("SnowflakeObject not found"));
         };
-        let Some(slush) = obj.as_any().downcast_ref::<SlushObject>() else {
+        let Some(snowflake) = obj.as_any().downcast_ref::<SnowflakeObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowflakeObject",
             ));
         };
-        Ok(slush.color)
+        Ok(snowflake.color)
+    }
+
+    pub async fn accepted(&self) -> Result<Option<Color>> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(crate::error::ChaincraftError::validation("SnowflakeObject not found"));
+        };
+        let Some(snowflake) = obj.as_any().downcast_ref::<SnowflakeObject>() else {
+            return Err(crate::error::ChaincraftError::validation(
+                "Object type mismatch for SnowflakeObject",
+            ));
+        };
+        Ok(snowflake.accepted)
     }
 
     pub async fn process_round(&mut self, round: u32) -> Result<bool> {
         let mut registry = self.node.app_objects.write().await;
         let Some(obj) = registry.objects.get_mut(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+            return Err(crate::error::ChaincraftError::validation("SnowflakeObject not found"));
         };
-        let Some(slush) = obj.as_any_mut().downcast_mut::<SlushObject>() else {
+        let Some(snowflake) = obj.as_any_mut().downcast_mut::<SnowflakeObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowflakeObject",
             ));
         };
-        let flipped = slush.process_round(round);
-        slush.current_round = round;
+        let flipped = snowflake.process_round(round);
+        snowflake.current_round = round;
         Ok(flipped)
     }
 
-    pub async fn finalize(&mut self) -> Result<Option<Color>> {
-        let mut registry = self.node.app_objects.write().await;
-        let Some(obj) = registry.objects.get_mut(&self.object_id) else {
-            return Err(crate::error::ChaincraftError::validation("SlushObject not found"));
+    pub async fn state_snapshot(&self) -> Result<(Option<Color>, Option<Color>, u32)> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(crate::error::ChaincraftError::validation("SnowflakeObject not found"));
         };
-        let Some(slush) = obj.as_any_mut().downcast_mut::<SlushObject>() else {
+        let Some(snowflake) = obj.as_any().downcast_ref::<SnowflakeObject>() else {
             return Err(crate::error::ChaincraftError::validation(
-                "Object type mismatch for SlushObject",
+                "Object type mismatch for SnowflakeObject",
             ));
         };
-        slush.finalize();
-        Ok(slush.accepted)
+        Ok((snowflake.color, snowflake.accepted, snowflake.consecutive_count))
     }
 }
 
 #[async_trait]
-impl ApplicationObject for SlushObject {
+impl ApplicationObject for SnowflakeObject {
     fn id(&self) -> &SharedObjectId {
         &self.id
     }
 
     fn type_name(&self) -> &'static str {
-        "SlushObject"
+        "SnowflakeObject"
     }
 
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
-        let vote: std::result::Result<SlushVote, _> = serde_json::from_value(message.data.clone());
+        let vote: std::result::Result<SnowflakeVote, _> =
+            serde_json::from_value(message.data.clone());
         if let Ok(v) = vote {
-            return Ok(v.message_type == "SLUSH_VOTE");
+            return Ok(v.message_type == "SNOWFLAKE_VOTE");
         }
         Ok(false)
     }
@@ -255,7 +272,7 @@ impl ApplicationObject for SlushObject {
         }
         self.seen_hashes.insert(message.hash.clone());
 
-        let vote: SlushVote = match serde_json::from_value(message.data.clone()) {
+        let vote: SnowflakeVote = match serde_json::from_value(message.data.clone()) {
             Ok(v) => v,
             Err(_) => return Ok(()),
         };
@@ -273,7 +290,7 @@ impl ApplicationObject for SlushObject {
     }
 
     async fn get_latest_digest(&self) -> Result<String> {
-        Ok(format!("{:?}", self.color))
+        Ok(format!("{:?}", self.accepted.or(self.color)))
     }
 
     async fn has_digest(&self, _digest: &str) -> Result<bool> {
@@ -302,6 +319,7 @@ impl ApplicationObject for SlushObject {
             "color": format!("{:?}", self.color),
             "accepted": format!("{:?}", self.accepted),
             "round": self.current_round,
+            "consecutive_count": self.consecutive_count,
             "votes": self.votes.len(),
         }))
     }
@@ -310,6 +328,7 @@ impl ApplicationObject for SlushObject {
         self.color = None;
         self.accepted = None;
         self.current_round = 0;
+        self.consecutive_count = 0;
         self.votes.clear();
         self.seen_hashes.clear();
         Ok(())

--- a/src/examples/tendermint.rs
+++ b/src/examples/tendermint.rs
@@ -4,14 +4,18 @@ use crate::{
         KeyType, PrivateKey, PublicKey, Signature,
     },
     error::{ChaincraftError, Result},
+    network::PeerId,
     shared::{MessageType, SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    storage::MemoryStorage,
+    ChaincraftNode,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// Tendermint consensus message types
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -513,6 +517,58 @@ impl ApplicationObject for TendermintObject {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+}
+
+/// Typed node wrapper for Tendermint examples.
+pub struct TendermintNode {
+    node: ChaincraftNode,
+    object_id: SharedObjectId,
+}
+
+impl TendermintNode {
+    pub async fn new(port: u16) -> Result<Self> {
+        let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
+        node.set_port(port);
+        let object_id = node
+            .add_shared_object(Box::new(TendermintObject::new()?))
+            .await?;
+        Ok(Self { node, object_id })
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        self.node.start().await
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        self.node.close().await
+    }
+
+    pub async fn connect_to_peer(&mut self, addr: &str) -> Result<()> {
+        self.node.connect_to_peer(addr).await
+    }
+
+    pub fn host(&self) -> &str {
+        self.node.host()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.node.port()
+    }
+
+    pub async fn publish(&mut self, data: serde_json::Value) -> Result<String> {
+        self.node.create_shared_message_with_data(data).await
+    }
+
+    pub async fn state(&self) -> Result<(u64, u32, ConsensusState)> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.object_id) else {
+            return Err(ChaincraftError::validation("TendermintObject not found"));
+        };
+        let Some(tm) = obj.as_any().downcast_ref::<TendermintObject>() else {
+            return Err(ChaincraftError::validation("Object type mismatch for TendermintObject"));
+        };
+        Ok((tm.current_height, tm.current_round, tm.state.clone()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 // Modules
 pub mod consensus;
+pub mod core_objects;
 pub mod crypto;
 pub mod discovery;
 pub mod error;
@@ -29,6 +30,11 @@ pub use node::{clear_local_registry, ChaincraftNode};
 pub use shared::{SharedMessage, SharedObject, SharedObjectId, SharedObjectRegistry};
 
 // Application object re-exports
+pub use core_objects::{
+    BalanceLedger, Blockchain, CacheObject, CoreSharedObject, DAGObject, DocumentCache, Mempool,
+    MerkelizedObject, MerkleizedObject, NativeSharedObject, NonMerkelizedObject, TransactionChain,
+    UTXOLedger,
+};
 pub use shared_object::{
     ApplicationObject, ApplicationObjectRegistry, MerkelizedChain, MessageChain, SimpleSharedNumber,
 };

--- a/tests/test_core_objects.rs
+++ b/tests/test_core_objects.rs
@@ -1,0 +1,172 @@
+use chaincraft::shared::{MessageType, SharedMessage};
+use chaincraft::shared_object::ApplicationObject;
+use chaincraft::{
+    BalanceLedger, Blockchain, CacheObject, CoreSharedObject, DAGObject, DocumentCache, Mempool,
+    MerkelizedObject, NonMerkelizedObject, TransactionChain, UTXOLedger,
+};
+
+fn msg(data: serde_json::Value) -> SharedMessage {
+    SharedMessage::new(MessageType::Custom("test".to_string()), data)
+}
+
+#[tokio::test]
+async fn test_core_digest_stability() {
+    let a = serde_json::json!({"b": 2, "a": 1});
+    let b = serde_json::json!({"a": 1, "b": 2});
+    assert_eq!(CoreSharedObject::compute_digest(&a), CoreSharedObject::compute_digest(&b));
+}
+
+#[tokio::test]
+async fn test_non_merkelized_stubs() {
+    for obj in &mut [
+        Box::new(NonMerkelizedObject::new()) as Box<dyn ApplicationObject>,
+        Box::new(CacheObject::new()),
+        Box::new(Mempool::new()),
+        Box::new(DocumentCache::new()),
+    ] {
+        assert!(!obj.is_merkleized());
+        assert_eq!(obj.get_latest_digest().await.unwrap(), "");
+        assert!(!obj.has_digest("abc").await.unwrap());
+        assert!(!obj.is_valid_digest("abc").await.unwrap());
+        assert!(!obj.add_digest("abc".to_string()).await.unwrap());
+        assert!(obj.gossip_messages(Some("abc")).await.unwrap().is_empty());
+        assert!(obj
+            .get_messages_since_digest("abc")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}
+
+#[tokio::test]
+async fn test_merkelized_object_basic_digest_flow() {
+    let mut obj = MerkelizedObject::new();
+    obj.add_message(msg(serde_json::json!({"i": 1})))
+        .await
+        .unwrap();
+    let d1 = obj.get_latest_digest().await.unwrap();
+    obj.add_message(msg(serde_json::json!({"i": 2})))
+        .await
+        .unwrap();
+    let d2 = obj.get_latest_digest().await.unwrap();
+    assert_ne!(d1, "");
+    assert_ne!(d1, d2);
+    assert_eq!(obj.get_messages_since_digest(&d1).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_utxo_add_spend_flow() {
+    let mut ledger = UTXOLedger::new();
+    let add = msg(serde_json::json!({
+        "action": "utxo_add",
+        "utxo_id": "u1",
+        "amount": 5,
+        "owner": "alice"
+    }));
+    assert!(ledger.is_valid(&add).await.unwrap());
+    ledger.add_message(add).await.unwrap();
+    assert!(ledger.utxos.contains_key("u1"));
+
+    let spend = msg(serde_json::json!({"action": "utxo_spend", "utxo_id": "u1"}));
+    assert!(ledger.is_valid(&spend).await.unwrap());
+    ledger.add_message(spend).await.unwrap();
+    assert!(!ledger.utxos.contains_key("u1"));
+}
+
+#[tokio::test]
+async fn test_balance_ledger_credit_debit_transfer() {
+    let mut ledger = BalanceLedger::new();
+    ledger
+        .add_message(msg(serde_json::json!({
+            "action": "credit",
+            "account": "alice",
+            "amount": 10.0
+        })))
+        .await
+        .unwrap();
+    let debit = msg(serde_json::json!({"action": "debit", "account": "alice", "amount": 3.0}));
+    assert!(ledger.is_valid(&debit).await.unwrap());
+    ledger.add_message(debit).await.unwrap();
+
+    let transfer = msg(serde_json::json!({
+        "action": "transfer",
+        "from": "alice",
+        "to": "bob",
+        "amount": 4.0
+    }));
+    assert!(ledger.is_valid(&transfer).await.unwrap());
+    ledger.add_message(transfer).await.unwrap();
+    assert_eq!(ledger.balances.get("alice").cloned().unwrap_or(0.0), 3.0);
+    assert_eq!(ledger.balances.get("bob").cloned().unwrap_or(0.0), 4.0);
+}
+
+#[tokio::test]
+async fn test_blockchain_previous_digest_rules() {
+    let mut chain = Blockchain::new();
+    let genesis = msg(serde_json::json!({"previous_digest": "genesis", "height": 1}));
+    assert!(chain.is_valid(&genesis).await.unwrap());
+    chain.add_message(genesis).await.unwrap();
+    let prev = chain.blocks[0]["digest"].as_str().unwrap().to_string();
+    let next = msg(serde_json::json!({"previous_digest": prev, "height": 2}));
+    assert!(chain.is_valid(&next).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_dag_frontier_and_since_digest() {
+    let mut dag = DAGObject::new();
+    dag.add_message(msg(serde_json::json!({"parents": [], "payload": "root"})))
+        .await
+        .unwrap();
+    let root = dag.get_head_digests()[0].clone();
+    dag.add_message(msg(serde_json::json!({"parents": [root], "payload": "child"})))
+        .await
+        .unwrap();
+    let checkpoint = dag.get_latest_digest().await.unwrap();
+    let head = dag.get_head_digests()[0].clone();
+    dag.add_message(msg(serde_json::json!({"parents": [head], "payload": "child-2"})))
+        .await
+        .unwrap();
+    let delta = dag.get_messages_since_digest(&checkpoint).await.unwrap();
+    assert_eq!(delta.len(), 1);
+}
+
+#[tokio::test]
+async fn test_transaction_chain_tracks_order() {
+    let mut chain = TransactionChain::new();
+    chain
+        .add_message(msg(serde_json::json!({"tx_id": "a", "amount": 1})))
+        .await
+        .unwrap();
+    let d1 = chain.get_latest_digest().await.unwrap();
+    chain
+        .add_message(msg(serde_json::json!({"tx_id": "b", "amount": 2})))
+        .await
+        .unwrap();
+    assert_eq!(chain.transactions.len(), 2);
+    assert_eq!(chain.get_messages_since_digest(&d1).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_mempool_and_document_cache_ops() {
+    let mut mempool = Mempool::new();
+    mempool
+        .add_message(msg(serde_json::json!({"from": "a", "to": "b", "amount": 1})))
+        .await
+        .unwrap();
+    assert_eq!(mempool.transactions.len(), 1);
+    let tx_id = mempool.transactions.keys().next().unwrap().clone();
+    mempool
+        .add_message(msg(serde_json::json!({"tx_id": tx_id, "action": "remove"})))
+        .await
+        .unwrap();
+    assert!(mempool.transactions.is_empty());
+
+    let mut docs = DocumentCache::new();
+    docs.add_message(msg(serde_json::json!({
+        "document_id": "d1",
+        "value": {"title": "hello"}
+    })))
+    .await
+    .unwrap();
+    assert_eq!(docs.documents["d1"]["title"], "hello");
+}

--- a/tests/test_shared_objects.rs
+++ b/tests/test_shared_objects.rs
@@ -1,9 +1,6 @@
 use chaincraft::{
-    clear_local_registry,
-    network::PeerId,
-    shared_object::{ApplicationObject, SimpleSharedNumber},
-    storage::MemoryStorage,
-    ChaincraftNode,
+    clear_local_registry, network::PeerId, shared_object::ApplicationObject,
+    storage::MemoryStorage, BalanceLedger, ChaincraftNode,
 };
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
@@ -20,9 +17,9 @@ async fn create_network(num_nodes: usize) -> Vec<ChaincraftNode> {
         node.set_port(0);
         node.disable_local_discovery();
 
-        // Add a SimpleSharedNumber object to each node
-        let shared_number: Box<dyn ApplicationObject> = Box::new(SimpleSharedNumber::new());
-        node.add_shared_object(shared_number).await.unwrap();
+        // Add a BalanceLedger object to each node.
+        let ledger: Box<dyn ApplicationObject> = Box::new(BalanceLedger::new());
+        node.add_shared_object(ledger).await.unwrap();
 
         node.start().await.unwrap();
         nodes.push(node);
@@ -75,8 +72,13 @@ async fn test_shared_object_propagation() {
 
     // Create messages from each node
     for i in 0..nodes.len() {
-        let value = (i + 1) as i64;
-        let data = serde_json::json!(value);
+        let value = (i + 1) as f64;
+        let account = format!("user-{i}");
+        let data = serde_json::json!({
+            "action": "credit",
+            "account": account,
+            "amount": value,
+        });
         nodes[i]
             .create_shared_message_with_data(data)
             .await
@@ -88,29 +90,23 @@ async fn test_shared_object_propagation() {
         for (j, n) in nodes.iter().enumerate() {
             let shared_objects = n.shared_objects().await;
             if let Some(obj) = shared_objects.first() {
-                if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-                    println!("Node {}: Shared number: {}", j, shared_number.get_number());
+                if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+                    println!("Node {}: Ledger entries: {}", j, ledger.balances.len());
                 }
             }
         }
     }
 
-    // Calculate expected total
-    let expected_number: i64 = (1..=num_nodes as i64).sum();
-
-    // Wait for propagation (simplified - in a real network this would involve gossip protocol)
-    // For now, we just verify that each node processed its own message
+    // Wait for propagation (simplified); verify each node processed its own message at least.
     for (i, node) in nodes.iter().enumerate() {
         let shared_objects = node.shared_objects().await;
         if let Some(obj) = shared_objects.first() {
-            if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-                // Each node should have processed at least its own message
-                assert!(shared_number.get_number() >= (i + 1) as i64);
+            if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+                let account = format!("user-{i}");
+                assert!(ledger.balances.get(&account).cloned().unwrap_or(0.0) >= (i + 1) as f64);
             }
         }
     }
-
-    println!("Expected total after all propagation: {expected_number}");
 
     // Clean up
     for mut node in nodes {
@@ -123,8 +119,11 @@ async fn test_message_deduplication() {
     let mut node = create_network(1).await.into_iter().next().unwrap();
 
     // Send the same message multiple times
-    let test_value = 42;
-    let data = serde_json::json!(test_value);
+    let data = serde_json::json!({
+        "action": "credit",
+        "account": "alice",
+        "amount": 42.0,
+    });
 
     for _ in 0..5 {
         node.create_shared_message_with_data(data.clone())
@@ -132,12 +131,11 @@ async fn test_message_deduplication() {
             .unwrap();
     }
 
-    // Verify the shared number only incremented once due to deduplication
+    // Verify the ledger only increments once due to digest deduplication.
     let shared_objects = node.shared_objects().await;
     if let Some(obj) = shared_objects.first() {
-        if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-            assert_eq!(shared_number.get_number(), test_value);
-            assert_eq!(shared_number.get_messages().len(), 1);
+        if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+            assert_eq!(ledger.balances.get("alice").cloned().unwrap_or(0.0), 42.0);
         }
     }
 
@@ -150,24 +148,26 @@ async fn test_shared_object_state() {
     let mut node = create_network(1).await.into_iter().next().unwrap();
 
     // Add multiple messages
-    let values = vec![10, 20, 30];
+    let values = vec![10.0, 20.0, 30.0];
     for value in &values {
-        let data = serde_json::json!(value);
+        let data = serde_json::json!({
+            "action": "credit",
+            "account": "alice",
+            "amount": value,
+        });
         node.create_shared_message_with_data(data).await.unwrap();
     }
 
     // Verify the state
     let shared_objects = node.shared_objects().await;
     if let Some(obj) = shared_objects.first() {
-        if let Some(shared_number) = obj.as_any().downcast_ref::<SimpleSharedNumber>() {
-            let expected_sum: i64 = values.iter().sum();
-            assert_eq!(shared_number.get_number(), expected_sum);
-            assert_eq!(shared_number.get_messages().len(), values.len());
+        if let Some(ledger) = obj.as_any().downcast_ref::<BalanceLedger>() {
+            let expected_sum: f64 = values.iter().sum();
+            assert_eq!(ledger.balances.get("alice").cloned().unwrap_or(0.0), expected_sum);
 
             // Test state as JSON
             let state = obj.get_state().await.unwrap();
-            assert_eq!(state["number"], expected_sum);
-            assert_eq!(state["message_count"], values.len());
+            assert_eq!(state["balance_count"], 1);
         }
     }
 


### PR DESCRIPTION
## Summary
- Ports missing Avalanche-family examples to Rust by adding `Snowflake` and `Snowball` protocol example modules and runnable binaries.
- Adds typed wrapper nodes (composition over `ChaincraftNode`) for protocol examples to simplify setup/start/connect/publish/state flows.
- Refactors existing examples to use typed wrappers and keeps Rust usage aligned with `chaincraft-rust/SPECS.md`.
- Bumps crate patch version to `0.3.1` and updates version references.

## Changes
- Added:
  - `src/examples/snowflake.rs`
  - `src/examples/snowball.rs`
  - `examples/snowflake_example.rs`
  - `examples/snowball_example.rs`
- Updated:
  - `src/examples/mod.rs` (exports for new modules)
  - `src/examples/slush.rs` (typed `SlushNode`)
  - `src/examples/chatroom.rs` (typed `ChatroomNode`)
  - `src/examples/randomness_beacon.rs` (typed `RandomnessBeaconNode`)
  - `src/examples/ecdsa_ledger.rs` (typed `ECDSALedgerNode`)
  - `src/examples/tendermint.rs` (typed `TendermintNode`)
  - Example binaries refactored to wrapper APIs:
    - `examples/slush_example.rs`
    - `examples/chatroom_example.rs`
    - `examples/randomness_beacon_example.rs`
    - `examples/ecdsa_ledger_example.rs`
- Release metadata:
  - `Cargo.toml` version `0.3.0` -> `0.3.1`
  - `README.md` dependency snippets updated to `0.3.1`
  - `Cargo.lock` refreshed

## Validation
- `cargo check --examples`
- `cargo run --example slush_example`
- `cargo run --example snowflake_example`
- `cargo run --example snowball_example`
- `cargo run --example chatroom_example`
- `cargo run --example randomness_beacon_example`
- `cargo run --example ecdsa_ledger_example`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #35