### PR TITLE
Release v0.4.0: migrate to Memento pipeline and multi-block reorg support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaincraft"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaincraft"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Chaincraft Contributors"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add Chaincraft Rust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = "0.3.2"
+chaincraft = "0.4.0"
 ```
 
 ### Basic Example
@@ -195,7 +195,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = { version = "0.3.2", features = ["persistent", "indexing"] }
+chaincraft = { version = "0.4.0", features = ["persistent", "indexing"] }
 ```
 
 ## Development
@@ -257,6 +257,11 @@ Check out the `examples/` directory for more usage examples:
 - `keypair_generation.rs`: Cryptographic keypair generation and signing
 - `chatroom_example.rs`: Decentralized chatroom protocol (create rooms, post messages)
 - `randomness_beacon_example.rs`: Verifiable randomness beacon
+- `ecdsa_ledger_example.rs`: Signed transfer ledger workflow
+- `slush_example.rs`: Avalanche-family Slush consensus demo
+- `snowflake_example.rs`: Avalanche-family Snowflake consensus demo
+- `snowball_example.rs`: Avalanche-family Snowball consensus demo
+- `blockchain_example.rs`: Memento-aware blockchain pipeline demo
 - `shared_objects_example.rs`: Multi-node network with shared object propagation
 - `proof_of_work_example.rs`: Proof of Work mining and verification
 
@@ -266,7 +271,17 @@ Run examples with:
 cargo run --example basic_node
 cargo run --example chatroom_example
 cargo run --example shared_objects_example
+cargo run --example blockchain_example
 ```
+
+## SPECS v2 (Memento Pipeline)
+
+Rust `0.4.x` targets the SPECS v2 contract:
+
+- `ApplicationObject::add_message(message, frontier_state)` receives an optional memento.
+- Runtime validates all objects first, then processes them linearly.
+- Each object can emit a `StateMemento` forwarded to downstream objects.
+- Messages are persisted and broadcast only after successful pipeline execution.
 
 ## Contributing
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,250 +1,161 @@
-# Chaincraft Rust Protocol Specification v1
+# Chaincraft Rust Protocol Specification v2
 
-This document describes how to implement protocols with `chaincraft-rust`.
+This document defines the Rust `0.4.x` protocol contract.
 
-You write protocol/application logic; Chaincraft runtime handles UDP networking,
-message propagation, deduplication, storage, peer tracking, and background tasks.
+You implement protocol logic only. Chaincraft handles UDP networking, gossip,
+deduplication, storage, peer management, and pipeline orchestration.
 
 ## Architecture Overview
 
 ```
-┌──────────────────────────────────────────────────────────────────────┐
-│                            ChaincraftNode                            │
-│                                                                      │
-│  ┌────────────────────────────────────────────────────────────────┐  │
-│  │ start_networking()                                             │  │
-│  │ - UDP receive loop                                             │  │
-│  │ - gossip rebroadcast loop                                      │  │
-│  │ - direct control/P2P path (non-gossip sync and requests)       │  │
-│  └────────────────────────────────────────────────────────────────┘  │
-│                                                                      │
-│  Incoming UDP datagram                                               │
-│   ├── SharedMessage gossip path                                      │
-│   │    ├── dedupe by hash + store                                    │
-│   │    ├── app_objects.process_message(msg)                          │
-│   │    │    ├── object.is_valid(msg)                                 │
-│   │    │    └── if valid => object.add_message(msg)                  │
-│   │    └── rebroadcast to peers                                      │
-│   │                                                                  │
-│   └── Direct control/P2P path (no gossip fanout)                     │
-│        └── REQUEST_DIGEST / REQUEST_MESSAGES_SINCE / responses       │
-│                                                                      │
-└──────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│                           ChaincraftNode                         │
+│                                                                  │
+│  inbound datagram                                                 │
+│     ├─ control path (direct): REQUEST_DIGEST / REQUEST_MESSAGES  │
+│     └─ gossip path: SharedMessage                                │
+│           ├─ dedupe check by hash                                │
+│           ├─ process_message(msg)                                │
+│           │    1) validate all objects (all-or-nothing)          │
+│           │    2) linear apply pipeline                          │
+│           │       add_message(msg, frontier_state?)              │
+│           │       -> Option<StateMemento>                        │
+│           │       -> emitted/fallback memento passed downstream  │
+│           ├─ persist only on successful pipeline                 │
+│           └─ rebroadcast                                          │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ## Core Abstractions
 
-### `SharedMessage`
+### `StateMemento`
 
-Transport envelope exchanged between nodes as JSON.
-
-Key fields:
-
-- `id: SharedObjectId`
-- `message_type: MessageType`
-- `target_id: Option<SharedObjectId>`
-- `data: serde_json::Value`
-- `timestamp`
-- `signature: Option<Vec<u8>>`
-- `hash`
-
-Create messages with:
+Pipeline snapshot propagated object-to-object in one message pass.
 
 ```rust
-use chaincraft::shared::{MessageType, SharedMessage};
+use chaincraft::{StateMemento, normalize_state_memento};
 
-let msg = SharedMessage::new(
-    MessageType::Custom("MY_VOTE".to_string()),
-    serde_json::json!({"round": 7, "vote": "yes"}),
-);
+let m: StateMemento = normalize_state_memento("tip_digest", Some(vec![
+    "tip_digest".to_string()
+]));
 ```
+
+Fields:
+- `canonical_digest`
+- `frontier_digests`
+- `revision`
+- `metadata` (string map for reorg/catch-up hints)
 
 ### `ApplicationObject`
 
-Protocols are implemented as `ApplicationObject` implementations.
-
-Main methods:
-
-- `is_valid(&self, message) -> Result<bool>`
-- `add_message(&mut self, message) -> Result<()>`
-- `is_merkleized() -> bool`
-- digest methods (`get_latest_digest`, `has_digest`, `is_valid_digest`, `add_digest`)
-- sync methods (`gossip_messages`, `get_messages_since_digest`)
-- lifecycle/state (`get_state`, `reset`)
-
-### `ChaincraftNode`
-
-Runtime entrypoint for networking and protocol dispatch.
-
-Important methods:
-
-- `start()` / `close()`
-- `connect_to_peer("host:port")`
-- `add_shared_object(Box<dyn ApplicationObject>)`
-- `create_shared_message_with_data(serde_json::Value)`
-- `create_shared_message(String)` (compatibility helper)
-
-## Message Types and P2P Control Messages
-
-`MessageType` supports both application messages and protocol control plane messages.
-
-Built-in control types include:
-
-- `PEER_DISCOVERY`, `REQUEST_LOCAL_PEERS`, `LOCAL_PEERS`
-- `REQUEST_SHARED_OBJECT_UPDATE`, `SHARED_OBJECT_UPDATE`
-- `REQUEST_DIGEST`, `DIGEST_RESPONSE`
-- `REQUEST_MESSAGES_SINCE`, `MESSAGES_RESPONSE`
-- `GET`, `SET`, `DELETE`, `RESPONSE`, `NOTIFICATION`, `HEARTBEAT`, `ERROR`
-
-For protocol-specific traffic, use `MessageType::Custom("...")`.
-
-Example data payload with explicit type:
+`ApplicationObject` is the protocol contract.
 
 ```rust
-let data = serde_json::json!({
-    "type": "SLUSH_VOTE",
-    "round": 3,
-    "color": "red"
-});
-node.create_shared_message_with_data(data).await?;
+#[async_trait]
+pub trait ApplicationObject {
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool>;
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>>;
+    async fn emit_state_memento(&self) -> Result<StateMemento>;
+    fn get_state_digests(&self) -> Vec<String>;
+    // ... digest/sync/state/reset methods ...
+}
 ```
 
-## Message Flow (Gossip/Data Path)
+Rules:
+- `is_valid` must be deterministic and side-effect free.
+- `add_message` mutates state and can emit a new memento.
+- If `add_message` emits `None`, the runtime uses `emit_state_memento()`.
 
-### Outbound (local create)
+### `SharedMessage`
 
-`create_shared_message_with_data(data)` performs:
+Transport envelope exchanged over network:
+- `message_type`, `data`, `timestamp`, `hash`, `signature`, etc.
 
-1. Resolve `MessageType` from `data["type"]` (or default custom type).
-2. Build `SharedMessage`.
-3. Store message in node storage.
-4. Run `ApplicationObjectRegistry::process_message`.
-5. Broadcast JSON payload over UDP to known peers.
+## Pipeline Semantics (v2)
 
-### Inbound (from peer datagram)
+`ApplicationObjectRegistry::process_message`:
 
-Receive loop performs:
+1. Validate message against **all** registered objects.
+2. If any object rejects, abort pipeline (message rejected).
+3. If all valid, process objects sequentially in registration order.
+4. Pass `frontier_state` memento from one object to the next.
 
-1. Parse control/digest messages first.
-2. Else parse datagram as `SharedMessage`.
-3. Deduplicate by `hash` (skip if already stored).
-4. Store in node storage.
-5. Dispatch via `process_message`.
-6. Re-broadcast to peers for propagation.
+This gives deterministic multi-object state transitions and supports
+reorg/catch-up coordination between related objects.
 
-## Request/Response and Sync Path
+## Storage/Broadcast Ordering
 
-Rust runtime includes a control-plane request/response path over UDP JSON:
+For both local and inbound gossip messages:
+- Run validation + apply pipeline first.
+- Persist and broadcast only if pipeline succeeds.
 
-- `REQUEST_DIGEST` -> `DIGEST_RESPONSE`
-- `REQUEST_MESSAGES_SINCE` -> `MESSAGES_RESPONSE`
+This avoids committing invalid state transitions to storage.
 
-When digests differ, peers request missing messages and apply them through the
-same `process_message` path used by normal gossip.
+## Direct P2P / Control Path
 
-This is the Rust equivalent of direct synchronization traffic: messages are
-point-to-point UDP exchanges but still represented in JSON and integrated with
-object-level digest methods.
+Non-gossip control messages (`REQUEST_DIGEST`, `REQUEST_MESSAGES_SINCE`,
+responses) are direct UDP request/response messages.
 
-## Validation and Processing Semantics
+They are not regular gossip fanout objects, but replayed `SharedMessage`s from
+sync responses are still routed through the same v2 pipeline.
 
-`ApplicationObjectRegistry::process_message` evaluates each registered object
-sequentially:
+## Merkelized vs Non-Merkelized
 
-1. `object.is_valid(&message)`
-2. If valid for that object, call `object.add_message(message.clone())`
-3. Continue to next object
-
-Important: processing is per-object. A rejection in one object does not prevent
-other objects from processing if they validate the same message.
-
-## Merkelized vs Non-Merkelized Objects
-
-Use merkelized objects when digest-based state sync matters:
-
-- chains
-- DAGs
-- ledgers/state snapshots
-
-Use non-merkelized objects when gossip plus hash deduplication is enough:
-
-- mempool queues
-- transient caches
-- loosely ordered event streams
-
-For non-merkelized objects, keep digest methods simple/minimal and return empty
-sync payloads as appropriate.
+Use merkelized objects when canonical/frontier digests matter (chain, DAG,
+ledger snapshots). Use non-merkelized objects for eventually-consistent queues
+or caches where digest proofs are unnecessary.
 
 ## Rust Core Objects
 
-The crate exposes Python-aligned core objects:
+Core object families:
+- merkelized: `MerkelizedObject`, `UTXOLedger`, `BalanceLedger`, `Blockchain`,
+  `DAGObject`, `TransactionChain`
+- non-merkelized: `NonMerkelizedObject`, `CacheObject`, `Mempool`,
+  `DocumentCache`
 
-- Merkelized:
-  - `MerkelizedObject`
-  - `UTXOLedger`
-  - `BalanceLedger`
-  - `Blockchain`
-  - `DAGObject`
-  - `TransactionChain`
-- Non-merkelized:
-  - `NonMerkelizedObject`
-  - `CacheObject`
-  - `Mempool`
-  - `DocumentCache`
-
-Compatibility aliases:
-
+Aliases:
 - `MerkleizedObject` -> `MerkelizedObject`
 - `NativeSharedObject` -> `CoreSharedObject`
 
-## Implementing a Protocol
+## Examples (v2 contract)
 
-### 1) Define an `ApplicationObject`
+Protocol modules under `src/examples/` implement the v2 signature:
+- `chatroom`, `ecdsa_ledger`, `randomness_beacon`
+- `slush`, `snowflake`, `snowball`
+- `tendermint`
+- `blockchain` (memento-aware chain example)
 
-- Keep structural/state checks in `is_valid`.
-- Keep mutations in `add_message`.
-- Route by `message.message_type` or `message.data["type"]` inside `add_message`.
+Runnable examples under `examples/` use typed wrappers and node lifecycle:
+- `chatroom_example`
+- `ecdsa_ledger_example`
+- `randomness_beacon_example`
+- `slush_example`
+- `snowflake_example`
+- `snowball_example`
+- `blockchain_example`
 
-### 2) Register object(s) on a node
+## Minimal Usage
 
 ```rust
-use chaincraft::{network::PeerId, storage::MemoryStorage, BalanceLedger, ChaincraftNode};
+use chaincraft::{ChaincraftNode, PeerId, storage::MemoryStorage, BalanceLedger};
 use std::sync::Arc;
 
-let storage = Arc::new(MemoryStorage::new());
-let mut node = ChaincraftNode::new(PeerId::new(), storage);
+let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
 node.add_shared_object(Box::new(BalanceLedger::new())).await?;
-```
-
-### 3) Start networking and connect peers
-
-```rust
 node.start().await?;
-node.connect_to_peer("127.0.0.1:9001").await?;
-```
-
-### 4) Publish protocol messages
-
-```rust
 node.create_shared_message_with_data(serde_json::json!({
-    "type": "MY_PROTOCOL_EVENT",
+    "type": "MY_EVENT",
     "payload": {"x": 42}
 })).await?;
 ```
 
-## Threading and Concurrency Guidance
+## Protocol Author Checklist
 
-- Do not manage sockets or manual networking in protocol objects.
-- Do not create parallel protocol runtimes for message handling.
-- Keep object logic deterministic and idempotent where possible.
-- If external tasks touch shared protocol state, protect internal invariants.
-
-## What Protocol Authors Should Not Reimplement
-
-- UDP gossip fanout
-- message hash deduplication
-- peer discovery bookkeeping
-- digest-sync transport exchange
-- node lifecycle orchestration
-
-Use the provided node/runtime APIs and focus on protocol-specific state machines.
+- Keep `is_valid` strict and side-effect free.
+- Return stable mementos from `add_message` when your object is canonical owner.
+- Implement `get_state_digests` for multi-head structures (DAG/forks).
+- Do not reimplement sockets, gossip fanout, or node threading.

--- a/examples/blockchain_example.rs
+++ b/examples/blockchain_example.rs
@@ -1,0 +1,53 @@
+//! Blockchain Example (Memento v2 pipeline)
+//!
+//! Run with: `cargo run --example blockchain_example`
+
+use chaincraft::{blockchain_helpers as helpers, error::Result, BlockchainNode};
+use tokio::time::{sleep, Duration};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    println!("Chaincraft Blockchain Example");
+    println!("=============================\n");
+
+    let mut node = BlockchainNode::new(0).await?;
+    node.start().await?;
+
+    let tx = helpers::create_tx_message(serde_json::json!({
+        "from": "alice",
+        "to": "bob",
+        "amount": 5
+    }));
+    node.publish(tx).await?;
+    sleep(Duration::from_millis(100)).await;
+
+    let state = node.chain_state().await?;
+    let previous_digest = state
+        .get("latest_digest")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let height = state
+        .get("latest_height")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0)
+        + 1;
+
+    let block = helpers::create_block_message(
+        height,
+        previous_digest,
+        serde_json::json!({"transactions": [{"from":"alice","to":"bob","amount":5}]}),
+    );
+    node.publish(block).await?;
+    sleep(Duration::from_millis(150)).await;
+
+    println!(
+        "Blockchain state: {}",
+        serde_json::to_string_pretty(&node.chain_state().await?).unwrap_or_default()
+    );
+
+    node.close().await?;
+    Ok(())
+}

--- a/src/core_objects.rs
+++ b/src/core_objects.rs
@@ -4,6 +4,7 @@ use crate::{
     error::Result,
     shared::{SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
 };
 use async_trait::async_trait;
 use lru::LruCache;
@@ -330,8 +331,12 @@ impl ApplicationObject for NonMerkelizedObject {
         Ok(true)
     }
 
-    async fn add_message(&mut self, _message: SharedMessage) -> Result<()> {
-        Ok(())
+    async fn add_message(
+        &mut self,
+        _message: SharedMessage,
+        _frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {
@@ -420,16 +425,20 @@ impl ApplicationObject for MerkelizedObject {
         Ok(true)
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let digest = compute_digest_value(&message.data);
         if self.state.contains_digest(&digest) {
-            return Ok(());
+            return Ok(None);
         }
         let parents = extract_parent_digests(&message.data);
         self.state
             .record_message(&mut self.storage, message, digest, parents)
             .await;
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {
@@ -545,10 +554,14 @@ impl ApplicationObject for UTXOLedger {
             _ => Ok(false),
         }
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let digest = compute_digest_value(&message.data);
         if self.state.contains_digest(&digest) {
-            return Ok(());
+            return Ok(None);
         }
         let parents = extract_parent_digests(&message.data);
         self.state
@@ -575,7 +588,7 @@ impl ApplicationObject for UTXOLedger {
                 self.storage.delete(&format!("utxo:{utxo_id}")).await;
             }
         }
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         true
@@ -684,10 +697,14 @@ impl ApplicationObject for BalanceLedger {
             _ => Ok(false),
         }
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let digest = compute_digest_value(&message.data);
         if self.state.contains_digest(&digest) {
-            return Ok(());
+            return Ok(None);
         }
         let parents = extract_parent_digests(&message.data);
         self.state
@@ -738,7 +755,7 @@ impl ApplicationObject for BalanceLedger {
             },
             _ => {},
         }
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         true
@@ -839,10 +856,14 @@ impl ApplicationObject for Blockchain {
             .unwrap_or_default();
         Ok(prev == last)
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let digest = compute_digest_value(&message.data);
         if self.state.contains_digest(&digest) {
-            return Ok(());
+            return Ok(None);
         }
         let parents = extract_parent_digests(&message.data);
         self.state
@@ -859,7 +880,7 @@ impl ApplicationObject for Blockchain {
             .unwrap_or_default()
             .to_string();
         self.storage.write(&format!("block:{key}"), block).await;
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         true
@@ -978,10 +999,14 @@ impl ApplicationObject for DAGObject {
         }
         Ok(true)
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let digest = compute_digest_value(&message.data);
         if self.state.contains_digest(&digest) {
-            return Ok(());
+            return Ok(None);
         }
         let parents = extract_parent_digests(&message.data);
         self.state
@@ -998,7 +1023,7 @@ impl ApplicationObject for DAGObject {
         let frontier = self.current_frontier_digest();
         self.frontier_state_index
             .insert(frontier, (self.state.messages.len() as isize) - 1);
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         true
@@ -1099,10 +1124,14 @@ impl ApplicationObject for TransactionChain {
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
         Ok(message.data.is_object())
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let digest = compute_digest_value(&message.data);
         if self.state.contains_digest(&digest) {
-            return Ok(());
+            return Ok(None);
         }
         let parents = extract_parent_digests(&message.data);
         self.state
@@ -1116,7 +1145,7 @@ impl ApplicationObject for TransactionChain {
             .unwrap_or_default()
             .to_string();
         self.storage.write(&format!("tx:{key}"), tx).await;
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         true
@@ -1199,7 +1228,11 @@ impl ApplicationObject for CacheObject {
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
         Ok(message.data.is_object())
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let data = message.data.as_object().cloned().unwrap_or_default();
         let key = data
             .get("key")
@@ -1210,13 +1243,13 @@ impl ApplicationObject for CacheObject {
         if data.get("action").and_then(|v| v.as_str()) == Some("delete") {
             self.cache.remove(&key);
             self.storage.delete(&key).await;
-            return Ok(());
+            return Ok(None);
         }
 
         let value = data.get("value").cloned().unwrap_or(message.data);
         self.cache.insert(key.clone(), value.clone());
         self.storage.write(&key, value).await;
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         false
@@ -1293,7 +1326,11 @@ impl ApplicationObject for Mempool {
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
         Ok(message.data.is_object())
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let tx = message.data.as_object().cloned().unwrap_or_default();
         let tx_id = tx
             .get("tx_id")
@@ -1305,7 +1342,7 @@ impl ApplicationObject for Mempool {
             self.transactions.remove(&tx_id);
             self.cache.remove(&tx_id);
             self.storage.delete(&format!("mempool:{tx_id}")).await;
-            return Ok(());
+            return Ok(None);
         }
         let as_value = Value::Object(tx);
         self.transactions.insert(tx_id.clone(), as_value.clone());
@@ -1313,7 +1350,7 @@ impl ApplicationObject for Mempool {
         self.storage
             .write(&format!("mempool:{tx_id}"), as_value)
             .await;
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         false
@@ -1391,7 +1428,11 @@ impl ApplicationObject for DocumentCache {
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
         Ok(message.data.is_object())
     }
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let data = message.data.as_object().cloned().unwrap_or_default();
         let doc_id = data
             .get("doc_id")
@@ -1405,7 +1446,7 @@ impl ApplicationObject for DocumentCache {
             self.documents.remove(&doc_id);
             self.cache.remove(&doc_id);
             self.storage.delete(&format!("doc:{doc_id}")).await;
-            return Ok(());
+            return Ok(None);
         }
 
         let payload = data
@@ -1416,7 +1457,7 @@ impl ApplicationObject for DocumentCache {
         self.documents.insert(doc_id.clone(), payload.clone());
         self.cache.insert(doc_id.clone(), payload.clone());
         self.storage.write(&format!("doc:{doc_id}"), payload).await;
-        Ok(())
+        Ok(None)
     }
     fn is_merkleized(&self) -> bool {
         false

--- a/src/examples/blockchain.rs
+++ b/src/examples/blockchain.rs
@@ -1,4 +1,844 @@
-//! Blockchain example implementation
+//! Blockchain protocol example with Memento-aware pipeline state.
 
-/// Placeholder for blockchain example
-pub struct BlockchainExample; 
+use crate::{
+    error::{ChaincraftError, Result},
+    network::PeerId,
+    shared::{MessageType, SharedMessage, SharedObjectId},
+    shared_object::ApplicationObject,
+    state_memento::{normalize_state_memento, StateMemento},
+    storage::MemoryStorage,
+    ChaincraftNode,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::any::Any;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockRecord {
+    pub height: u64,
+    pub digest: String,
+    pub previous_digest: String,
+    pub miner: String,
+    pub transactions: Vec<Value>,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockchainObject {
+    id: SharedObjectId,
+    pub chain: Vec<BlockRecord>,
+    pub balances: HashMap<String, i64>,
+    pub mining_reward: i64,
+    block_by_digest: HashMap<String, BlockRecord>,
+    children_by_digest: HashMap<String, HashSet<String>>,
+    tip_digests: HashSet<String>,
+    state_by_digest: HashMap<String, HashMap<String, i64>>,
+    seen_hashes: HashSet<String>,
+}
+
+impl BlockchainObject {
+    pub fn new() -> Self {
+        Self::with_reward(10)
+    }
+
+    pub fn with_reward(mining_reward: i64) -> Self {
+        let genesis_digest = Self::compute_digest(&serde_json::json!({
+            "height": 0u64,
+            "previous_digest": "",
+            "miner": "genesis",
+            "transactions": [],
+            "payload": "genesis"
+        }));
+        let genesis = BlockRecord {
+            height: 0,
+            digest: genesis_digest.clone(),
+            previous_digest: String::new(),
+            miner: "genesis".to_string(),
+            transactions: vec![],
+            payload: serde_json::json!("genesis"),
+        };
+        let mut block_by_digest = HashMap::new();
+        block_by_digest.insert(genesis_digest.clone(), genesis.clone());
+        let mut children_by_digest = HashMap::new();
+        children_by_digest.insert(genesis_digest.clone(), HashSet::new());
+        let mut tip_digests = HashSet::new();
+        tip_digests.insert(genesis_digest.clone());
+        let mut balances = HashMap::new();
+        balances.insert("genesis".to_string(), 1000);
+        let mut state_by_digest = HashMap::new();
+        state_by_digest.insert(genesis_digest.clone(), balances.clone());
+
+        Self {
+            id: SharedObjectId::new(),
+            chain: vec![genesis],
+            balances,
+            mining_reward,
+            block_by_digest,
+            children_by_digest,
+            tip_digests,
+            state_by_digest,
+            seen_hashes: HashSet::new(),
+        }
+    }
+
+    fn canonical_json(value: &Value) -> Value {
+        match value {
+            Value::Object(map) => {
+                let mut keys: Vec<String> = map.keys().cloned().collect();
+                keys.sort();
+                let mut out = serde_json::Map::new();
+                for key in keys {
+                    if let Some(v) = map.get(&key) {
+                        out.insert(key, Self::canonical_json(v));
+                    }
+                }
+                Value::Object(out)
+            },
+            Value::Array(arr) => Value::Array(arr.iter().map(Self::canonical_json).collect()),
+            _ => value.clone(),
+        }
+    }
+
+    fn compute_digest(value: &Value) -> String {
+        let canonical = Self::canonical_json(value);
+        let payload = serde_json::to_string(&canonical).unwrap_or_else(|_| "null".to_string());
+        let mut hasher = Sha256::new();
+        hasher.update(payload.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    pub fn latest_block(&self) -> &BlockRecord {
+        self.chain
+            .last()
+            .expect("blockchain always has genesis block")
+    }
+
+    fn compute_next_state(
+        &self,
+        parent_state: &HashMap<String, i64>,
+        block: &BlockRecord,
+    ) -> Result<HashMap<String, i64>> {
+        let mut next = parent_state.clone();
+        *next.entry(block.miner.clone()).or_insert(0) += self.mining_reward;
+        for tx in &block.transactions {
+            let sender = tx
+                .get("sender")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ChaincraftError::validation("transaction missing sender"))?
+                .to_string();
+            let recipient = tx
+                .get("recipient")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ChaincraftError::validation("transaction missing recipient"))?
+                .to_string();
+            let amount = tx
+                .get("amount")
+                .and_then(|v| v.as_i64())
+                .ok_or_else(|| ChaincraftError::validation("transaction missing amount"))?;
+            let fee = tx
+                .get("fee")
+                .and_then(|v| v.as_i64())
+                .ok_or_else(|| ChaincraftError::validation("transaction missing fee"))?;
+            let sender_balance = *next.get(&sender).unwrap_or(&0);
+            if sender_balance < amount + fee {
+                return Err(ChaincraftError::validation(
+                    "sender has insufficient balance for transaction",
+                ));
+            }
+            next.insert(sender.clone(), sender_balance - amount - fee);
+            *next.entry(recipient).or_insert(0) += amount;
+            *next.entry(block.miner.clone()).or_insert(0) += fee;
+        }
+        Ok(next)
+    }
+
+    fn build_chain_to_tip(&self, tip_digest: &str) -> Vec<BlockRecord> {
+        let mut reversed = vec![];
+        let mut cursor = tip_digest.to_string();
+        while let Some(block) = self.block_by_digest.get(&cursor) {
+            reversed.push(block.clone());
+            if block.height == 0 {
+                break;
+            }
+            cursor = block.previous_digest.clone();
+        }
+        reversed.reverse();
+        if reversed.first().map(|b| b.height) == Some(0) {
+            reversed
+        } else {
+            vec![]
+        }
+    }
+
+    fn is_better_tip(&self, candidate_digest: &str, current_digest: &str) -> bool {
+        let Some(candidate) = self.block_by_digest.get(candidate_digest) else {
+            return false;
+        };
+        let Some(current) = self.block_by_digest.get(current_digest) else {
+            return true;
+        };
+        if candidate.height > current.height {
+            return true;
+        }
+        if candidate.height < current.height {
+            return false;
+        }
+        candidate_digest < current_digest
+    }
+
+    fn collect_transactions(&self, digests: &[String]) -> Vec<Value> {
+        let mut txs = vec![];
+        for digest in digests {
+            if let Some(block) = self.block_by_digest.get(digest) {
+                for tx in &block.transactions {
+                    txs.push(tx.clone());
+                }
+            }
+        }
+        txs
+    }
+
+    fn build_memento(
+        &self,
+        reorg: bool,
+        reorg_from_height: Option<u64>,
+        reverted_txs: Vec<Value>,
+        applied_tx_ids: Vec<String>,
+    ) -> StateMemento {
+        let latest = self.latest_block().digest.clone();
+        let mut frontier = self
+            .chain
+            .iter()
+            .rev()
+            .take(8)
+            .map(|b| b.digest.clone())
+            .collect::<Vec<_>>();
+        let canonical_set: HashSet<String> = frontier.iter().cloned().collect();
+        let mut extras = self
+            .tip_digests
+            .iter()
+            .filter(|d| !canonical_set.contains(*d))
+            .cloned()
+            .collect::<Vec<_>>();
+        extras.sort();
+        frontier.extend(extras);
+
+        let mut memento = normalize_state_memento(&latest, Some(frontier));
+        memento.revision = self.chain.len() as u64;
+        let mut metadata = BTreeMap::new();
+        metadata.insert("reorg".to_string(), Value::Bool(reorg));
+        if let Some(height) = reorg_from_height {
+            metadata.insert(
+                "reorg_from_height".to_string(),
+                Value::Number(serde_json::Number::from(height)),
+            );
+        }
+        metadata.insert("reverted_txs".to_string(), Value::Array(reverted_txs));
+        metadata.insert(
+            "applied_tx_ids".to_string(),
+            Value::Array(applied_tx_ids.into_iter().map(Value::String).collect()),
+        );
+        metadata.insert(
+            "chain_length".to_string(),
+            Value::Number(serde_json::Number::from(self.chain.len())),
+        );
+        memento.metadata = metadata;
+        memento
+    }
+}
+
+impl Default for BlockchainObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for BlockchainObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "BlockchainObject"
+    }
+
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let data = &message.data;
+        let Some(message_type) = data.get("message_type").and_then(|v| v.as_str()) else {
+            return Ok(false);
+        };
+        match message_type {
+            "NEW_TX" => Ok(data.get("tx").and_then(|v| v.get("tx_id")).is_some()),
+            "NEW_BLOCK" => {
+                let Some(height) = data.get("height").and_then(|v| v.as_u64()) else {
+                    return Ok(false);
+                };
+                let Some(previous_digest) = data.get("previous_digest").and_then(|v| v.as_str())
+                else {
+                    return Ok(false);
+                };
+                let Some(miner) = data.get("miner").and_then(|v| v.as_str()) else {
+                    return Ok(false);
+                };
+                if miner.is_empty() {
+                    return Ok(false);
+                }
+                let Some(transactions) = data.get("transactions").and_then(|v| v.as_array()) else {
+                    return Ok(false);
+                };
+                let Some(payload) = data.get("payload") else {
+                    return Ok(false);
+                };
+                let computed = Self::compute_digest(&serde_json::json!({
+                    "height": height,
+                    "previous_digest": previous_digest,
+                    "miner": miner,
+                    "transactions": transactions,
+                    "payload": payload
+                }));
+                let provided = data
+                    .get("digest")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                if computed != provided {
+                    return Ok(false);
+                }
+
+                let Some(parent) = self.block_by_digest.get(previous_digest) else {
+                    return Ok(false);
+                };
+                if height != parent.height + 1 {
+                    return Ok(false);
+                }
+                let Some(parent_state) = self.state_by_digest.get(previous_digest) else {
+                    return Ok(false);
+                };
+                let candidate = BlockRecord {
+                    height,
+                    digest: provided.to_string(),
+                    previous_digest: previous_digest.to_string(),
+                    miner: miner.to_string(),
+                    transactions: transactions.clone(),
+                    payload: payload.clone(),
+                };
+                Ok(self.compute_next_state(parent_state, &candidate).is_ok())
+            },
+            _ => Ok(false),
+        }
+    }
+
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        _frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
+        if self.seen_hashes.contains(&message.hash) {
+            return Ok(None);
+        }
+        self.seen_hashes.insert(message.hash.clone());
+
+        let data = message.data;
+        let message_type = data
+            .get("message_type")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ChaincraftError::validation("missing message_type"))?;
+
+        match message_type {
+            "NEW_TX" => Ok(Some(self.build_memento(false, None, vec![], vec![]))),
+            "NEW_BLOCK" => {
+                let height = data
+                    .get("height")
+                    .and_then(|v| v.as_u64())
+                    .ok_or_else(|| ChaincraftError::validation("missing block height"))?;
+                let previous_digest = data
+                    .get("previous_digest")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ChaincraftError::validation("missing previous_digest"))?
+                    .to_string();
+                let payload = data
+                    .get("payload")
+                    .cloned()
+                    .ok_or_else(|| ChaincraftError::validation("missing payload"))?;
+                let miner = data
+                    .get("miner")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ChaincraftError::validation("missing miner"))?
+                    .to_string();
+                let transactions = data
+                    .get("transactions")
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| ChaincraftError::validation("missing transactions"))?
+                    .clone();
+                let digest = data
+                    .get("digest")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ChaincraftError::validation("missing digest"))?
+                    .to_string();
+
+                let block = BlockRecord {
+                    height,
+                    digest: digest.clone(),
+                    previous_digest: previous_digest.clone(),
+                    miner,
+                    transactions: transactions.clone(),
+                    payload,
+                };
+                if self.block_by_digest.contains_key(&digest) {
+                    return Ok(Some(self.build_memento(false, None, vec![], vec![])));
+                }
+                let parent_state = self
+                    .state_by_digest
+                    .get(&previous_digest)
+                    .ok_or_else(|| ChaincraftError::validation("missing parent state"))?
+                    .clone();
+                let next_state = self.compute_next_state(&parent_state, &block)?;
+
+                let old_chain_hashes = self
+                    .chain
+                    .iter()
+                    .map(|b| b.digest.clone())
+                    .collect::<Vec<_>>();
+                let old_tip = self.latest_block().digest.clone();
+
+                self.block_by_digest.insert(digest.clone(), block.clone());
+                self.children_by_digest
+                    .entry(previous_digest.clone())
+                    .or_default()
+                    .insert(digest.clone());
+                self.children_by_digest.entry(digest.clone()).or_default();
+                self.state_by_digest.insert(digest.clone(), next_state);
+                self.tip_digests.insert(digest.clone());
+                self.tip_digests.remove(&previous_digest);
+
+                let mut reorg = false;
+                let mut reorg_from_height = None;
+                if self.is_better_tip(&digest, &old_tip) {
+                    let new_chain = self.build_chain_to_tip(&digest);
+                    if !new_chain.is_empty() {
+                        self.chain = new_chain;
+                        self.balances = self
+                            .state_by_digest
+                            .get(&digest)
+                            .cloned()
+                            .unwrap_or_default();
+                    }
+                }
+
+                let new_chain_hashes = self
+                    .chain
+                    .iter()
+                    .map(|b| b.digest.clone())
+                    .collect::<Vec<_>>();
+                let old_set: HashSet<String> = old_chain_hashes.iter().cloned().collect();
+                let new_set: HashSet<String> = new_chain_hashes.iter().cloned().collect();
+                let removed = old_chain_hashes
+                    .into_iter()
+                    .filter(|h| !new_set.contains(h))
+                    .collect::<Vec<_>>();
+                let added = new_chain_hashes
+                    .iter()
+                    .filter(|h| !old_set.contains(*h))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if !removed.is_empty() {
+                    reorg = true;
+                    let min_height = removed
+                        .iter()
+                        .filter_map(|h| self.block_by_digest.get(h).map(|b| b.height))
+                        .min();
+                    reorg_from_height = min_height;
+                }
+                let reverted_txs = self.collect_transactions(&removed);
+                let applied_tx_ids = self
+                    .collect_transactions(&added)
+                    .iter()
+                    .filter_map(|tx| tx.get("tx_id").and_then(|v| v.as_str()))
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>();
+
+                Ok(Some(self.build_memento(reorg, reorg_from_height, reverted_txs, applied_tx_ids)))
+            },
+            _ => Ok(None),
+        }
+    }
+
+    fn is_merkleized(&self) -> bool {
+        true
+    }
+
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.latest_block().digest.clone())
+    }
+
+    async fn has_digest(&self, digest: &str) -> Result<bool> {
+        Ok(self.block_by_digest.contains_key(digest))
+    }
+
+    async fn is_valid_digest(&self, digest: &str) -> Result<bool> {
+        self.has_digest(digest).await
+    }
+
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    fn get_state_digests(&self) -> Vec<String> {
+        let mut canonical = self
+            .chain
+            .iter()
+            .rev()
+            .take(8)
+            .map(|b| b.digest.clone())
+            .collect::<Vec<_>>();
+        canonical.reverse();
+        let canonical_set: HashSet<String> = canonical.iter().cloned().collect();
+        let mut extras = self
+            .tip_digests
+            .iter()
+            .filter(|d| !canonical_set.contains(*d))
+            .cloned()
+            .collect::<Vec<_>>();
+        extras.sort();
+        canonical.extend(extras);
+        canonical
+    }
+
+    async fn emit_state_memento(&self) -> Result<StateMemento> {
+        Ok(self.build_memento(false, None, vec![], vec![]))
+    }
+
+    async fn get_state(&self) -> Result<Value> {
+        Ok(serde_json::json!({
+            "chain_length": self.chain.len(),
+            "latest_digest": self.latest_block().digest,
+            "latest_height": self.latest_block().height,
+            "balances": self.balances
+        }))
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        let genesis = self.chain.first().cloned();
+        self.chain.clear();
+        if let Some(genesis) = genesis {
+            self.chain.push(genesis.clone());
+            self.block_by_digest.clear();
+            self.block_by_digest
+                .insert(genesis.digest.clone(), genesis.clone());
+            self.children_by_digest.clear();
+            self.children_by_digest
+                .insert(genesis.digest.clone(), HashSet::new());
+            self.tip_digests.clear();
+            self.tip_digests.insert(genesis.digest.clone());
+            self.state_by_digest.clear();
+            let mut balances = HashMap::new();
+            balances.insert("genesis".to_string(), 1000);
+            self.balances = balances.clone();
+            self.state_by_digest.insert(genesis.digest, balances);
+        }
+        self.seen_hashes.clear();
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MempoolObject {
+    id: SharedObjectId,
+    pub transactions: BTreeMap<String, Value>,
+}
+
+impl MempoolObject {
+    pub fn new() -> Self {
+        Self {
+            id: SharedObjectId::new(),
+            transactions: BTreeMap::new(),
+        }
+    }
+}
+
+impl Default for MempoolObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApplicationObject for MempoolObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "MempoolObject"
+    }
+
+    async fn is_valid(&self, message: &SharedMessage) -> Result<bool> {
+        let msg_type = message
+            .data
+            .get("message_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        Ok(matches!(msg_type, "NEW_TX" | "NEW_BLOCK"))
+    }
+
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
+        let msg_type = message
+            .data
+            .get("message_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        match msg_type {
+            "NEW_TX" => {
+                if let Some(tx) = message.data.get("tx").cloned() {
+                    if let Some(tx_id) = tx.get("tx_id").and_then(|v| v.as_str()) {
+                        self.transactions.insert(tx_id.to_string(), tx);
+                    }
+                }
+            },
+            "NEW_BLOCK" => {
+                let metadata = frontier_state.map(|m| m.metadata).unwrap_or_default();
+                let reverted = metadata
+                    .get("reverted_txs")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                for tx in reverted {
+                    if let Some(tx_id) = tx.get("tx_id").and_then(|v| v.as_str()) {
+                        self.transactions.insert(tx_id.to_string(), tx);
+                    }
+                }
+                let applied = metadata
+                    .get("applied_tx_ids")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                if !applied.is_empty() {
+                    for tx_id in applied {
+                        if let Some(tx_id) = tx_id.as_str() {
+                            self.transactions.remove(tx_id);
+                        }
+                    }
+                } else if let Some(block_txs) = message
+                    .data
+                    .get("transactions")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                {
+                    for tx in block_txs {
+                        if let Some(tx_id) = tx.get("tx_id").and_then(|v| v.as_str()) {
+                            self.transactions.remove(tx_id);
+                        }
+                    }
+                }
+            },
+            _ => {},
+        }
+        Ok(Some(self.emit_state_memento().await?))
+    }
+
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+
+    async fn get_latest_digest(&self) -> Result<String> {
+        Ok(self.transactions.len().to_string())
+    }
+
+    async fn has_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn is_valid_digest(&self, _digest: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn add_digest(&mut self, _digest: String) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn gossip_messages(&self, _digest: Option<&str>) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+
+    async fn get_state(&self) -> Result<Value> {
+        Ok(serde_json::json!({
+            "mempool_size": self.transactions.len()
+        }))
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        self.transactions.clear();
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Typed node wrapper for Blockchain examples.
+pub struct BlockchainNode {
+    node: ChaincraftNode,
+    ledger_object_id: SharedObjectId,
+    mempool_object_id: SharedObjectId,
+}
+
+impl BlockchainNode {
+    pub async fn new(port: u16) -> Result<Self> {
+        let mut node = ChaincraftNode::new(PeerId::new(), Arc::new(MemoryStorage::new()));
+        node.set_port(port);
+        let ledger_object_id = node
+            .add_shared_object(Box::new(BlockchainObject::new()))
+            .await?;
+        let mempool_object_id = node
+            .add_shared_object(Box::new(MempoolObject::new()))
+            .await?;
+        Ok(Self {
+            node,
+            ledger_object_id,
+            mempool_object_id,
+        })
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        self.node.start().await
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        self.node.close().await
+    }
+
+    pub async fn connect_to_peer(&mut self, addr: &str) -> Result<()> {
+        self.node.connect_to_peer(addr).await
+    }
+
+    pub fn host(&self) -> &str {
+        self.node.host()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.node.port()
+    }
+
+    pub async fn publish(&mut self, data: Value) -> Result<String> {
+        self.node.create_shared_message_with_data(data).await
+    }
+
+    pub async fn chain_state(&self) -> Result<Value> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.ledger_object_id) else {
+            return Err(ChaincraftError::validation("BlockchainObject not found"));
+        };
+        obj.get_state().await
+    }
+
+    pub async fn mempool_state(&self) -> Result<Value> {
+        let registry = self.node.app_objects.read().await;
+        let Some(obj) = registry.get(&self.mempool_object_id) else {
+            return Err(ChaincraftError::validation("MempoolObject not found"));
+        };
+        obj.get_state().await
+    }
+}
+
+pub mod helpers {
+    use super::*;
+
+    pub fn create_tx_message(tx: Value) -> Value {
+        serde_json::json!({
+            "message_type": "NEW_TX",
+            "tx": tx
+        })
+    }
+
+    pub fn create_block_message(height: u64, previous_digest: String, payload: Value) -> Value {
+        create_block_message_with_transactions(
+            height,
+            previous_digest,
+            "miner".to_string(),
+            vec![],
+            payload,
+        )
+    }
+
+    pub fn create_block_message_with_transactions(
+        height: u64,
+        previous_digest: String,
+        miner: String,
+        transactions: Vec<Value>,
+        payload: Value,
+    ) -> Value {
+        let digest = BlockchainObject::compute_digest(&serde_json::json!({
+            "height": height,
+            "previous_digest": previous_digest,
+            "miner": miner,
+            "transactions": transactions,
+            "payload": payload
+        }));
+        serde_json::json!({
+            "message_type": "NEW_BLOCK",
+            "height": height,
+            "previous_digest": previous_digest,
+            "miner": miner,
+            "transactions": transactions,
+            "payload": payload,
+            "digest": digest
+        })
+    }
+
+    pub fn create_simple_transfer_tx(
+        tx_id: &str,
+        sender: &str,
+        recipient: &str,
+        amount: i64,
+        fee: i64,
+    ) -> Value {
+        serde_json::json!({
+            "tx_id": tx_id,
+            "sender": sender,
+            "recipient": recipient,
+            "amount": amount,
+            "fee": fee,
+        })
+    }
+}

--- a/src/examples/chatroom.rs
+++ b/src/examples/chatroom.rs
@@ -17,6 +17,7 @@ use crate::{
     network::PeerId,
     shared::{MessageType, SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
     storage::MemoryStorage,
     ChaincraftNode,
 };
@@ -401,7 +402,11 @@ impl ApplicationObject for ChatroomObject {
         Ok(msg_result.is_ok())
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let msg: ChatroomMessageType =
             serde_json::from_value(message.data.clone()).map_err(|e| {
                 ChaincraftError::Serialization(crate::error::SerializationError::Json(e))
@@ -432,7 +437,7 @@ impl ApplicationObject for ChatroomObject {
             tracing::warn!("Failed to process chatroom message: {:?}", msg);
         }
 
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {

--- a/src/examples/ecdsa_ledger.rs
+++ b/src/examples/ecdsa_ledger.rs
@@ -9,6 +9,7 @@ use crate::{
     network::PeerId,
     shared::{SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
     storage::MemoryStorage,
     ChaincraftNode,
 };
@@ -142,7 +143,11 @@ impl ApplicationObject for ECDSALedgerObject {
         }
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let msg: LedgerMessageType = serde_json::from_value(message.data.clone())
             .map_err(|_| ChaincraftError::validation("Invalid ledger message format"))?;
 
@@ -157,22 +162,22 @@ impl ApplicationObject for ECDSALedgerObject {
             } => {
                 let tx_hash = Self::tx_hash(&from, &to, amount, nonce);
                 if self.seen_tx_hashes.contains(&tx_hash) {
-                    return Ok(());
+                    return Ok(None);
                 }
 
                 let msg_data = message.data.clone();
                 if !self.validate_signature(&msg_data, &signature, &public_key_pem)? {
-                    return Ok(());
+                    return Ok(None);
                 }
 
                 let from_balance = *self.balances.get(&from).unwrap_or(&0);
                 let expected_nonce = *self.nonces.get(&from).unwrap_or(&0);
                 if nonce != expected_nonce {
-                    return Ok(());
+                    return Ok(None);
                 }
                 // Allow first tx from new address (genesis/mint for demo)
                 if from_balance < amount && from_balance > 0 {
-                    return Ok(());
+                    return Ok(None);
                 }
 
                 self.seen_tx_hashes.insert(tx_hash);
@@ -187,7 +192,7 @@ impl ApplicationObject for ECDSALedgerObject {
                 }
                 *self.balances.entry(to).or_insert(0) += amount;
                 self.nonces.insert(from, nonce + 1);
-                Ok(())
+                Ok(None)
             },
         }
     }

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -1,3 +1,4 @@
+pub mod blockchain;
 pub mod chatroom;
 pub mod ecdsa_ledger;
 pub mod randomness_beacon;

--- a/src/examples/randomness_beacon.rs
+++ b/src/examples/randomness_beacon.rs
@@ -7,6 +7,7 @@ use crate::{
     network::PeerId,
     shared::{MessageType, SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
     storage::MemoryStorage,
     ChaincraftNode,
 };
@@ -432,7 +433,11 @@ impl ApplicationObject for RandomnessBeaconObject {
         Ok(msg_result.is_ok())
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let beacon_msg: BeaconMessageType =
             serde_json::from_value(message.data.clone()).map_err(|e| {
                 ChaincraftError::Serialization(crate::error::SerializationError::Json(e))
@@ -486,7 +491,7 @@ impl ApplicationObject for RandomnessBeaconObject {
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {

--- a/src/examples/slush.rs
+++ b/src/examples/slush.rs
@@ -12,6 +12,7 @@ use crate::{
     network::PeerId,
     shared::{MessageType, SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
     storage::MemoryStorage,
     ChaincraftNode,
 };
@@ -249,15 +250,19 @@ impl ApplicationObject for SlushObject {
         Ok(false)
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         if self.seen_hashes.contains(&message.hash) {
-            return Ok(());
+            return Ok(None);
         }
         self.seen_hashes.insert(message.hash.clone());
 
         let vote: SlushVote = match serde_json::from_value(message.data.clone()) {
             Ok(v) => v,
-            Err(_) => return Ok(()),
+            Err(_) => return Ok(None),
         };
 
         if self.color.is_none() {
@@ -265,7 +270,7 @@ impl ApplicationObject for SlushObject {
         }
 
         self.votes.push(vote);
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {

--- a/src/examples/snowball.rs
+++ b/src/examples/snowball.rs
@@ -8,6 +8,7 @@ use crate::{
     network::PeerId,
     shared::{SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
     storage::MemoryStorage,
     ChaincraftNode,
 };
@@ -292,15 +293,19 @@ impl ApplicationObject for SnowballObject {
         Ok(false)
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         if self.seen_hashes.contains(&message.hash) {
-            return Ok(());
+            return Ok(None);
         }
         self.seen_hashes.insert(message.hash.clone());
 
         let vote: SnowballVote = match serde_json::from_value(message.data.clone()) {
             Ok(v) => v,
-            Err(_) => return Ok(()),
+            Err(_) => return Ok(None),
         };
 
         if self.preference.is_none() {
@@ -309,7 +314,7 @@ impl ApplicationObject for SnowballObject {
         }
 
         self.votes.push(vote);
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {

--- a/src/examples/snowflake.rs
+++ b/src/examples/snowflake.rs
@@ -8,6 +8,7 @@ use crate::{
     network::PeerId,
     shared::{SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
     storage::MemoryStorage,
     ChaincraftNode,
 };
@@ -266,15 +267,19 @@ impl ApplicationObject for SnowflakeObject {
         Ok(false)
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         if self.seen_hashes.contains(&message.hash) {
-            return Ok(());
+            return Ok(None);
         }
         self.seen_hashes.insert(message.hash.clone());
 
         let vote: SnowflakeVote = match serde_json::from_value(message.data.clone()) {
             Ok(v) => v,
-            Err(_) => return Ok(()),
+            Err(_) => return Ok(None),
         };
 
         if self.color.is_none() {
@@ -282,7 +287,7 @@ impl ApplicationObject for SnowflakeObject {
         }
 
         self.votes.push(vote);
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {

--- a/src/examples/tendermint.rs
+++ b/src/examples/tendermint.rs
@@ -7,6 +7,7 @@ use crate::{
     network::PeerId,
     shared::{MessageType, SharedMessage, SharedObjectId},
     shared_object::ApplicationObject,
+    state_memento::StateMemento,
     storage::MemoryStorage,
     ChaincraftNode,
 };
@@ -384,7 +385,11 @@ impl ApplicationObject for TendermintObject {
         Ok(msg_result.is_ok())
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let tendermint_msg: TendermintMessageType = serde_json::from_value(message.data.clone())
             .map_err(|e| {
                 ChaincraftError::Serialization(crate::error::SerializationError::Json(e))
@@ -425,7 +430,7 @@ impl ApplicationObject for TendermintObject {
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod network;
 pub mod node;
 pub mod shared;
 pub mod shared_object;
+pub mod state_memento;
 pub mod storage;
 pub mod types;
 pub mod utils;
@@ -28,12 +29,16 @@ pub use error::{ChaincraftError, Result};
 pub use network::{PeerId, PeerInfo};
 pub use node::{clear_local_registry, ChaincraftNode};
 pub use shared::{SharedMessage, SharedObject, SharedObjectId, SharedObjectRegistry};
+pub use state_memento::{normalize_state_memento, StateMemento};
 
 // Application object re-exports
 pub use core_objects::{
     BalanceLedger, Blockchain, CacheObject, CoreSharedObject, DAGObject, DocumentCache, Mempool,
     MerkelizedObject, MerkleizedObject, NativeSharedObject, NonMerkelizedObject, TransactionChain,
     UTXOLedger,
+};
+pub use examples::blockchain::{
+    helpers as blockchain_helpers, BlockchainNode, BlockchainObject, MempoolObject,
 };
 pub use shared_object::{
     ApplicationObject, ApplicationObjectRegistry, MerkelizedChain, MessageChain, SimpleSharedNumber,

--- a/src/node.rs
+++ b/src/node.rs
@@ -469,11 +469,13 @@ impl ChaincraftNode {
         let message = SharedMessage::new(message_type, data.clone());
         let hash = message.hash.clone();
         let json = message.to_json()?;
-        // Store before processing
-        self.storage.put(&hash, json.as_bytes().to_vec()).await?;
-        // Process message through application objects
+        // Process message through application objects first (validation + pipeline).
         let mut app_registry = self.app_objects.write().await;
         let _processed = app_registry.process_message(message).await?;
+        drop(app_registry);
+
+        // Persist only after successful pipeline execution.
+        self.storage.put(&hash, json.as_bytes().to_vec()).await?;
 
         // Broadcast to peers over UDP if networking is enabled
         if let Some(socket) = &self.socket {
@@ -878,14 +880,16 @@ async fn handle_digest_sync_control(
                     continue;
                 }
                 let json = msg.to_json().unwrap_or_default();
+                {
+                    let mut registry = app_objects.write().await;
+                    if registry.process_message(msg.clone()).await.is_err() {
+                        continue;
+                    }
+                }
                 let _ = storage.put(&msg.hash, json.as_bytes().to_vec()).await;
                 {
                     let mut set = known_hashes.write().await;
                     set.insert(msg.hash.clone());
-                }
-                {
-                    let mut registry = app_objects.write().await;
-                    let _ = registry.process_message(msg.clone()).await;
                 }
                 let bytes = msg.to_json().unwrap_or_default().into_bytes();
                 let _ = broadcast_bytes(socket, peers, banned_peers, &bytes).await;
@@ -955,9 +959,7 @@ async fn handle_incoming_datagram(
         return Ok(());
     }
 
-    // Store message
     let json = msg.to_json()?;
-    storage.put(&msg.hash, json.as_bytes().to_vec()).await?;
 
     // Ensure peer is recorded (only if not banned)
     {
@@ -969,11 +971,14 @@ async fn handle_incoming_datagram(
         }
     }
 
-    // Process through application objects
+    // Process through application objects first (validation + pipeline).
     {
         let mut registry = app_objects.write().await;
         let _ = registry.process_message(msg.clone()).await?;
     }
+
+    // Persist message only after successful pipeline execution.
+    storage.put(&msg.hash, json.as_bytes().to_vec()).await?;
 
     // Broadcast to other peers so the message propagates
     let bytes = json.into_bytes();

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,6 +1,7 @@
 //! Shared objects and messages for distributed state management
 
 use crate::error::{ChaincraftError, CryptoError, Result, SerializationError};
+use crate::state_memento::StateMemento;
 use async_trait::async_trait;
 use bincode;
 use hex;
@@ -376,7 +377,11 @@ pub trait SharedObject: Send + Sync + Debug {
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool>;
 
     /// Process a validated message and update the object state
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()>;
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>>;
 
     /// Check if this object supports merkleized synchronization
     fn is_merkleized(&self) -> bool;

--- a/src/shared_object.rs
+++ b/src/shared_object.rs
@@ -4,6 +4,7 @@ pub use crate::shared::SharedObjectId;
 use crate::{
     error::{ChaincraftError, Result},
     shared::{MessageType, SharedMessage, SharedObject},
+    state_memento::{normalize_state_memento, StateMemento},
 };
 use async_trait::async_trait;
 use chrono;
@@ -27,8 +28,12 @@ pub trait ApplicationObject: Send + Sync + std::fmt::Debug {
     /// Validate if a message is valid for this object
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool>;
 
-    /// Add a validated message to the object
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()>;
+    /// Add a validated message to the object and optionally emit updated frontier state.
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>>;
 
     /// Check if this object supports merkleized synchronization
     fn is_merkleized(&self) -> bool;
@@ -50,6 +55,18 @@ pub trait ApplicationObject: Send + Sync + std::fmt::Debug {
 
     /// Get messages since a specific digest
     async fn get_messages_since_digest(&self, digest: &str) -> Result<Vec<SharedMessage>>;
+
+    /// Return frontier digests for multi-head structures.
+    fn get_state_digests(&self) -> Vec<String> {
+        vec![]
+    }
+
+    /// Emit a normalized shared pipeline state memento.
+    async fn emit_state_memento(&self) -> Result<StateMemento> {
+        let latest_digest = self.get_latest_digest().await?;
+        let frontier_digests = self.get_state_digests();
+        Ok(normalize_state_memento(&latest_digest, Some(frontier_digests)))
+    }
 
     /// Get the current state as JSON
     async fn get_state(&self) -> Result<Value>;
@@ -134,13 +151,17 @@ impl ApplicationObject for SimpleSharedNumber {
         Ok(message.data.is_i64())
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        _frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         // Deduplicate by hashing the message's data field
         let msg_hash = Self::calculate_message_hash(&message.data);
 
         if self.seen_hashes.contains(&msg_hash) {
             // Already processed this data
-            return Ok(());
+            return Ok(None);
         }
 
         self.seen_hashes.insert(msg_hash);
@@ -152,7 +173,7 @@ impl ApplicationObject for SimpleSharedNumber {
             tracing::info!("SimpleSharedNumber: Added message with data: {}", value);
         }
 
-        Ok(())
+        Ok(Some(self.emit_state_memento().await?))
     }
 
     fn is_merkleized(&self) -> bool {
@@ -182,6 +203,15 @@ impl ApplicationObject for SimpleSharedNumber {
 
     async fn get_messages_since_digest(&self, _digest: &str) -> Result<Vec<SharedMessage>> {
         Ok(Vec::new())
+    }
+
+    fn get_state_digests(&self) -> Vec<String> {
+        let digest = self.number.to_string();
+        if digest.is_empty() {
+            vec![]
+        } else {
+            vec![digest]
+        }
     }
 
     async fn get_state(&self) -> Result<Value> {
@@ -381,14 +411,18 @@ impl ApplicationObject for MerkelizedChain {
         Ok(false)
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let Some(hash) = message.data.as_str() else {
-            return Ok(());
+            return Ok(None);
         };
 
         // Skip if already in chain
         if self.hash_set.contains(hash) {
-            return Ok(());
+            return Ok(None);
         }
 
         // Try to add to chain
@@ -400,7 +434,7 @@ impl ApplicationObject for MerkelizedChain {
             );
         }
 
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {
@@ -548,14 +582,18 @@ impl ApplicationObject for MessageChain {
         Ok(!message.data.is_null())
     }
 
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()> {
+    async fn add_message(
+        &mut self,
+        message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> Result<Option<StateMemento>> {
         let h = Self::msg_hash(&message);
         if self.seen_hashes.contains(&h) {
-            return Ok(());
+            return Ok(None);
         }
         self.seen_hashes.insert(h);
         self.messages.push(message);
-        Ok(())
+        Ok(None)
     }
 
     fn is_merkleized(&self) -> bool {
@@ -634,6 +672,7 @@ impl ApplicationObject for MessageChain {
 pub struct ApplicationObjectRegistry {
     pub objects: HashMap<SharedObjectId, Box<dyn ApplicationObject>>,
     objects_by_type: HashMap<String, Vec<SharedObjectId>>,
+    registration_order: Vec<SharedObjectId>,
 }
 
 impl ApplicationObjectRegistry {
@@ -641,6 +680,7 @@ impl ApplicationObjectRegistry {
         Self {
             objects: HashMap::new(),
             objects_by_type: HashMap::new(),
+            registration_order: Vec::new(),
         }
     }
 
@@ -654,6 +694,7 @@ impl ApplicationObjectRegistry {
             .or_default()
             .push(id.clone());
 
+        self.registration_order.push(id.clone());
         self.objects.insert(id.clone(), object);
         id
     }
@@ -686,6 +727,7 @@ impl ApplicationObjectRegistry {
                     self.objects_by_type.remove(&type_name);
                 }
             }
+            self.registration_order.retain(|obj_id| obj_id != id);
             Some(object)
         } else {
             None
@@ -694,7 +736,7 @@ impl ApplicationObjectRegistry {
 
     /// Get all object IDs
     pub fn ids(&self) -> Vec<SharedObjectId> {
-        self.objects.keys().cloned().collect()
+        self.registration_order.clone()
     }
 
     /// Get count of objects
@@ -711,30 +753,42 @@ impl ApplicationObjectRegistry {
     pub fn clear(&mut self) {
         self.objects.clear();
         self.objects_by_type.clear();
+        self.registration_order.clear();
     }
 
     /// Process a message against all appropriate objects
     pub async fn process_message(&mut self, message: SharedMessage) -> Result<Vec<SharedObjectId>> {
         let mut processed_objects = Vec::new();
 
-        // Get all object IDs first to avoid borrow checker issues
-        let ids: Vec<SharedObjectId> = self.objects.keys().cloned().collect();
+        // Get all object IDs first to avoid borrow checker issues.
+        let ids: Vec<SharedObjectId> = self.registration_order.clone();
 
-        // Process each object sequentially
-        for id in ids {
-            // Check validity first
-            let is_valid = if let Some(object) = self.objects.get(&id) {
+        // Validation-first: reject if any object rejects.
+        for id in &ids {
+            let is_valid = if let Some(object) = self.objects.get(id) {
                 object.is_valid(&message).await?
             } else {
                 false
             };
+            if !is_valid {
+                return Err(ChaincraftError::validation(
+                    "message rejected by at least one application object",
+                ));
+            }
+        }
 
-            // If valid, add the message
-            if is_valid {
-                if let Some(object) = self.objects.get_mut(&id) {
-                    object.add_message(message.clone()).await?;
-                    processed_objects.push(id);
-                }
+        // Sequential pipeline with optional frontier state memento propagation.
+        let mut frontier_state: Option<StateMemento> = None;
+        for id in ids {
+            if let Some(object) = self.objects.get_mut(&id) {
+                let emitted = object
+                    .add_message(message.clone(), frontier_state.clone())
+                    .await?;
+                frontier_state = match emitted {
+                    Some(memento) => Some(memento),
+                    None => Some(object.emit_state_memento().await?),
+                };
+                processed_objects.push(id);
             }
         }
 

--- a/src/state_memento.rs
+++ b/src/state_memento.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Immutable snapshot propagated between ApplicationObjects in one pipeline pass.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct StateMemento {
+    pub canonical_digest: String,
+    pub frontier_digests: Vec<String>,
+    pub revision: u64,
+    pub metadata: BTreeMap<String, Value>,
+}
+
+impl StateMemento {
+    /// Detect canonical replacement between two snapshots.
+    pub fn indicates_reorg_against(&self, previous: Option<&StateMemento>) -> bool {
+        let Some(previous) = previous else {
+            return false;
+        };
+        if previous.canonical_digest.is_empty() || self.canonical_digest.is_empty() {
+            return false;
+        }
+        if self.canonical_digest == previous.canonical_digest {
+            return false;
+        }
+        !self
+            .frontier_digests
+            .iter()
+            .any(|digest| digest == &previous.canonical_digest)
+    }
+}
+
+/// Create a normalized memento where frontier digests are unique and sorted.
+pub fn normalize_state_memento(
+    canonical_digest: &str,
+    frontier_digests: Option<Vec<String>>,
+) -> StateMemento {
+    let mut digests = frontier_digests.unwrap_or_default();
+    if !canonical_digest.is_empty() && !digests.iter().any(|d| d == canonical_digest) {
+        digests.push(canonical_digest.to_string());
+    }
+    digests.retain(|d| !d.is_empty());
+    digests.sort();
+    digests.dedup();
+
+    StateMemento {
+        canonical_digest: canonical_digest.to_string(),
+        frontier_digests: digests,
+        revision: 0,
+        metadata: BTreeMap::new(),
+    }
+}

--- a/src/temp.rs
+++ b/src/temp.rs
@@ -262,7 +262,7 @@ pub trait SharedObject: Send + Sync + Debug {
     async fn is_valid(&self, message: &SharedMessage) -> Result<bool>;
 
     /// Process a validated message and update the object state
-    async fn add_message(&mut self, message: SharedMessage) -> Result<()>;
+    async fn add_message(&mut self, message: SharedMessage, frontier_state: Option<StateMemento>) -> Result<Option<StateMemento>>;
 
     /// Check if this object supports merkleized synchronization
     fn is_merkleized(&self) -> bool;

--- a/tests/test_blockchain_reorgs.rs
+++ b/tests/test_blockchain_reorgs.rs
@@ -1,0 +1,303 @@
+use chaincraft::shared::{MessageType, SharedMessage};
+use chaincraft::{blockchain_helpers, ApplicationObject, BlockchainObject, MempoolObject};
+use serde_json::Value;
+
+fn msg(data: Value) -> SharedMessage {
+    SharedMessage::new(MessageType::Custom("BLOCKCHAIN".to_string()), data)
+}
+
+fn digest_of(data: &Value) -> String {
+    data.get("digest")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+async fn apply_pipeline(
+    ledger: &mut BlockchainObject,
+    mempool: &mut MempoolObject,
+    payload: Value,
+) -> chaincraft::StateMemento {
+    let message = msg(payload);
+    assert!(ledger.is_valid(&message).await.unwrap());
+    assert!(mempool.is_valid(&message).await.unwrap());
+    let state = ledger
+        .add_message(message.clone(), None)
+        .await
+        .unwrap()
+        .unwrap();
+    let _ = mempool
+        .add_message(message, Some(state.clone()))
+        .await
+        .unwrap();
+    state
+}
+
+#[tokio::test]
+async fn test_deep_reorg_reintroduces_reverted_transactions() {
+    let mut ledger = BlockchainObject::with_reward(10);
+    let mut mempool = MempoolObject::new();
+
+    let miner_a = "miner-a";
+    let miner_c = "miner-c";
+    let wallet_b = "wallet-b";
+
+    let genesis = ledger.latest_block().digest.clone();
+    let b1 = blockchain_helpers::create_block_message_with_transactions(
+        1,
+        genesis,
+        miner_a.to_string(),
+        vec![],
+        serde_json::json!({"id":"b1"}),
+    );
+    let _ = apply_pipeline(&mut ledger, &mut mempool, b1).await;
+
+    let tx1 = blockchain_helpers::create_simple_transfer_tx("tx-1", miner_a, wallet_b, 3, 1);
+    let tx1_msg = blockchain_helpers::create_tx_message(tx1.clone());
+    let _ = apply_pipeline(&mut ledger, &mut mempool, tx1_msg).await;
+    assert!(mempool.transactions.contains_key("tx-1"));
+
+    let block2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        ledger.latest_block().digest.clone(),
+        miner_a.to_string(),
+        vec![tx1.clone()],
+        serde_json::json!({"id":"b2"}),
+    );
+    let _ = apply_pipeline(&mut ledger, &mut mempool, block2).await;
+    assert!(!mempool.transactions.contains_key("tx-1"));
+
+    let block3 = blockchain_helpers::create_block_message_with_transactions(
+        3,
+        ledger.latest_block().digest.clone(),
+        miner_a.to_string(),
+        vec![],
+        serde_json::json!({"id":"b3"}),
+    );
+    let _ = apply_pipeline(&mut ledger, &mut mempool, block3).await;
+
+    let fork_b2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        ledger.chain[1].digest.clone(),
+        miner_c.to_string(),
+        vec![],
+        serde_json::json!({"id":"c2"}),
+    );
+    let fork_b2_digest = digest_of(&fork_b2);
+    let m2 = apply_pipeline(&mut ledger, &mut mempool, fork_b2).await;
+
+    let fork_b3 = blockchain_helpers::create_block_message_with_transactions(
+        3,
+        fork_b2_digest.clone(),
+        miner_c.to_string(),
+        vec![],
+        serde_json::json!({"id":"c3"}),
+    );
+    let fork_b3_digest = digest_of(&fork_b3);
+    let m3 = apply_pipeline(&mut ledger, &mut mempool, fork_b3).await;
+
+    let fork_b4 = blockchain_helpers::create_block_message_with_transactions(
+        4,
+        fork_b3_digest.clone(),
+        miner_c.to_string(),
+        vec![],
+        serde_json::json!({"id":"c4"}),
+    );
+    let fork_b4_digest = digest_of(&fork_b4);
+    let m4 = apply_pipeline(&mut ledger, &mut mempool, fork_b4).await;
+
+    let did_reorg = [m2, m3, m4]
+        .iter()
+        .any(|m| m.metadata.get("reorg") == Some(&serde_json::json!(true)));
+    assert!(did_reorg);
+    assert_eq!(ledger.latest_block().digest, fork_b4_digest);
+    assert!(mempool.transactions.contains_key("tx-1"));
+}
+
+#[tokio::test]
+async fn test_deep_reorg_does_not_reintroduce_reapplied_transaction() {
+    let mut ledger = BlockchainObject::with_reward(10);
+    let mut mempool = MempoolObject::new();
+
+    let miner_a = "miner-a";
+    let miner_c = "miner-c";
+    let wallet_b = "wallet-b";
+
+    let genesis = ledger.latest_block().digest.clone();
+    let b1 = blockchain_helpers::create_block_message_with_transactions(
+        1,
+        genesis,
+        miner_a.to_string(),
+        vec![],
+        serde_json::json!({"id":"b1"}),
+    );
+    let _ = apply_pipeline(&mut ledger, &mut mempool, b1).await;
+
+    let tx1 = blockchain_helpers::create_simple_transfer_tx("tx-1", miner_a, wallet_b, 2, 1);
+    let tx1_msg = blockchain_helpers::create_tx_message(tx1.clone());
+    let _ = apply_pipeline(&mut ledger, &mut mempool, tx1_msg).await;
+
+    let b2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        ledger.latest_block().digest.clone(),
+        miner_a.to_string(),
+        vec![tx1.clone()],
+        serde_json::json!({"id":"b2"}),
+    );
+    let _ = apply_pipeline(&mut ledger, &mut mempool, b2).await;
+
+    let b3 = blockchain_helpers::create_block_message_with_transactions(
+        3,
+        ledger.latest_block().digest.clone(),
+        miner_a.to_string(),
+        vec![],
+        serde_json::json!({"id":"b3"}),
+    );
+    let _ = apply_pipeline(&mut ledger, &mut mempool, b3).await;
+    assert!(!mempool.transactions.contains_key("tx-1"));
+
+    let c2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        ledger.chain[1].digest.clone(),
+        miner_c.to_string(),
+        vec![],
+        serde_json::json!({"id":"c2"}),
+    );
+    let c2_digest = digest_of(&c2);
+    let _ = apply_pipeline(&mut ledger, &mut mempool, c2).await;
+
+    let c3 = blockchain_helpers::create_block_message_with_transactions(
+        3,
+        c2_digest.clone(),
+        miner_c.to_string(),
+        vec![tx1.clone()],
+        serde_json::json!({"id":"c3"}),
+    );
+    let c3_digest = digest_of(&c3);
+    let _ = apply_pipeline(&mut ledger, &mut mempool, c3).await;
+
+    let c4 = blockchain_helpers::create_block_message_with_transactions(
+        4,
+        c3_digest.clone(),
+        miner_c.to_string(),
+        vec![],
+        serde_json::json!({"id":"c4"}),
+    );
+    let _ = apply_pipeline(&mut ledger, &mut mempool, c4).await;
+
+    assert!(!mempool.transactions.contains_key("tx-1"));
+}
+
+#[tokio::test]
+async fn test_coinbase_rewards_recomputed_after_deep_reorg() {
+    let mut ledger = BlockchainObject::with_reward(10);
+
+    let miner_a = "miner-a";
+    let miner_b = "miner-b";
+    let genesis = ledger.latest_block().digest.clone();
+
+    let a1 = blockchain_helpers::create_block_message_with_transactions(
+        1,
+        genesis,
+        miner_a.to_string(),
+        vec![],
+        serde_json::json!({"id":"a1"}),
+    );
+    let a1_digest = digest_of(&a1);
+    let _ = ledger.add_message(msg(a1), None).await.unwrap();
+    let a2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        ledger.latest_block().digest.clone(),
+        miner_a.to_string(),
+        vec![],
+        serde_json::json!({"id":"a2"}),
+    );
+    let _ = ledger.add_message(msg(a2), None).await.unwrap();
+    let a3 = blockchain_helpers::create_block_message_with_transactions(
+        3,
+        ledger.latest_block().digest.clone(),
+        miner_a.to_string(),
+        vec![],
+        serde_json::json!({"id":"a3"}),
+    );
+    let _ = ledger.add_message(msg(a3), None).await.unwrap();
+
+    let b2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        a1_digest,
+        miner_b.to_string(),
+        vec![],
+        serde_json::json!({"id":"b2"}),
+    );
+    let b2_digest = digest_of(&b2);
+    let _ = ledger.add_message(msg(b2), None).await.unwrap();
+    let b3 = blockchain_helpers::create_block_message_with_transactions(
+        3,
+        b2_digest,
+        miner_b.to_string(),
+        vec![],
+        serde_json::json!({"id":"b3"}),
+    );
+    let b3_digest = digest_of(&b3);
+    let _ = ledger.add_message(msg(b3), None).await.unwrap();
+    let b4 = blockchain_helpers::create_block_message_with_transactions(
+        4,
+        b3_digest,
+        miner_b.to_string(),
+        vec![],
+        serde_json::json!({"id":"b4"}),
+    );
+    let _ = ledger.add_message(msg(b4), None).await.unwrap();
+
+    assert_eq!(ledger.balances.get(miner_a).copied().unwrap_or(0), 10);
+    assert_eq!(ledger.balances.get(miner_b).copied().unwrap_or(0), 30);
+}
+
+#[tokio::test]
+async fn test_get_state_digests_includes_non_canonical_tip() {
+    let mut ledger = BlockchainObject::new();
+    let genesis = ledger.latest_block().digest.clone();
+
+    let canonical = blockchain_helpers::create_block_message_with_transactions(
+        1,
+        genesis.clone(),
+        "miner-a".to_string(),
+        vec![],
+        serde_json::json!({"id":"canonical"}),
+    );
+    let canonical_digest = digest_of(&canonical);
+    let _ = ledger.add_message(msg(canonical), None).await.unwrap();
+
+    let side = blockchain_helpers::create_block_message_with_transactions(
+        1,
+        genesis,
+        "miner-b".to_string(),
+        vec![],
+        serde_json::json!({"id":"side"}),
+    );
+    let side_digest = digest_of(&side);
+    let _ = ledger.add_message(msg(side), None).await.unwrap();
+
+    let digests = ledger.get_state_digests();
+    assert!(digests.contains(&canonical_digest));
+    assert!(digests.contains(&side_digest));
+}
+
+#[tokio::test]
+async fn test_mempool_block_fallback_without_memento() {
+    let mut mempool = MempoolObject::new();
+    let tx = blockchain_helpers::create_simple_transfer_tx("tx-1", "alice", "bob", 1, 1);
+    let tx_msg = msg(blockchain_helpers::create_tx_message(tx.clone()));
+    let _ = mempool.add_message(tx_msg, None).await.unwrap();
+    assert!(mempool.transactions.contains_key("tx-1"));
+
+    let block_msg = blockchain_helpers::create_block_message_with_transactions(
+        1,
+        "abc".to_string(),
+        "miner".to_string(),
+        vec![tx],
+        serde_json::json!({"id":"payload"}),
+    );
+    let _ = mempool.add_message(msg(block_msg), None).await.unwrap();
+    assert!(!mempool.transactions.contains_key("tx-1"));
+}

--- a/tests/test_core_objects.rs
+++ b/tests/test_core_objects.rs
@@ -41,11 +41,11 @@ async fn test_non_merkelized_stubs() {
 #[tokio::test]
 async fn test_merkelized_object_basic_digest_flow() {
     let mut obj = MerkelizedObject::new();
-    obj.add_message(msg(serde_json::json!({"i": 1})))
+    obj.add_message(msg(serde_json::json!({"i": 1})), None)
         .await
         .unwrap();
     let d1 = obj.get_latest_digest().await.unwrap();
-    obj.add_message(msg(serde_json::json!({"i": 2})))
+    obj.add_message(msg(serde_json::json!({"i": 2})), None)
         .await
         .unwrap();
     let d2 = obj.get_latest_digest().await.unwrap();
@@ -64,12 +64,12 @@ async fn test_utxo_add_spend_flow() {
         "owner": "alice"
     }));
     assert!(ledger.is_valid(&add).await.unwrap());
-    ledger.add_message(add).await.unwrap();
+    ledger.add_message(add, None).await.unwrap();
     assert!(ledger.utxos.contains_key("u1"));
 
     let spend = msg(serde_json::json!({"action": "utxo_spend", "utxo_id": "u1"}));
     assert!(ledger.is_valid(&spend).await.unwrap());
-    ledger.add_message(spend).await.unwrap();
+    ledger.add_message(spend, None).await.unwrap();
     assert!(!ledger.utxos.contains_key("u1"));
 }
 
@@ -77,16 +77,19 @@ async fn test_utxo_add_spend_flow() {
 async fn test_balance_ledger_credit_debit_transfer() {
     let mut ledger = BalanceLedger::new();
     ledger
-        .add_message(msg(serde_json::json!({
-            "action": "credit",
-            "account": "alice",
-            "amount": 10.0
-        })))
+        .add_message(
+            msg(serde_json::json!({
+                "action": "credit",
+                "account": "alice",
+                "amount": 10.0
+            })),
+            None,
+        )
         .await
         .unwrap();
     let debit = msg(serde_json::json!({"action": "debit", "account": "alice", "amount": 3.0}));
     assert!(ledger.is_valid(&debit).await.unwrap());
-    ledger.add_message(debit).await.unwrap();
+    ledger.add_message(debit, None).await.unwrap();
 
     let transfer = msg(serde_json::json!({
         "action": "transfer",
@@ -95,7 +98,7 @@ async fn test_balance_ledger_credit_debit_transfer() {
         "amount": 4.0
     }));
     assert!(ledger.is_valid(&transfer).await.unwrap());
-    ledger.add_message(transfer).await.unwrap();
+    ledger.add_message(transfer, None).await.unwrap();
     assert_eq!(ledger.balances.get("alice").cloned().unwrap_or(0.0), 3.0);
     assert_eq!(ledger.balances.get("bob").cloned().unwrap_or(0.0), 4.0);
 }
@@ -105,7 +108,7 @@ async fn test_blockchain_previous_digest_rules() {
     let mut chain = Blockchain::new();
     let genesis = msg(serde_json::json!({"previous_digest": "genesis", "height": 1}));
     assert!(chain.is_valid(&genesis).await.unwrap());
-    chain.add_message(genesis).await.unwrap();
+    chain.add_message(genesis, None).await.unwrap();
     let prev = chain.blocks[0]["digest"].as_str().unwrap().to_string();
     let next = msg(serde_json::json!({"previous_digest": prev, "height": 2}));
     assert!(chain.is_valid(&next).await.unwrap());
@@ -114,16 +117,16 @@ async fn test_blockchain_previous_digest_rules() {
 #[tokio::test]
 async fn test_dag_frontier_and_since_digest() {
     let mut dag = DAGObject::new();
-    dag.add_message(msg(serde_json::json!({"parents": [], "payload": "root"})))
+    dag.add_message(msg(serde_json::json!({"parents": [], "payload": "root"})), None)
         .await
         .unwrap();
     let root = dag.get_head_digests()[0].clone();
-    dag.add_message(msg(serde_json::json!({"parents": [root], "payload": "child"})))
+    dag.add_message(msg(serde_json::json!({"parents": [root], "payload": "child"})), None)
         .await
         .unwrap();
     let checkpoint = dag.get_latest_digest().await.unwrap();
     let head = dag.get_head_digests()[0].clone();
-    dag.add_message(msg(serde_json::json!({"parents": [head], "payload": "child-2"})))
+    dag.add_message(msg(serde_json::json!({"parents": [head], "payload": "child-2"})), None)
         .await
         .unwrap();
     let delta = dag.get_messages_since_digest(&checkpoint).await.unwrap();
@@ -134,12 +137,12 @@ async fn test_dag_frontier_and_since_digest() {
 async fn test_transaction_chain_tracks_order() {
     let mut chain = TransactionChain::new();
     chain
-        .add_message(msg(serde_json::json!({"tx_id": "a", "amount": 1})))
+        .add_message(msg(serde_json::json!({"tx_id": "a", "amount": 1})), None)
         .await
         .unwrap();
     let d1 = chain.get_latest_digest().await.unwrap();
     chain
-        .add_message(msg(serde_json::json!({"tx_id": "b", "amount": 2})))
+        .add_message(msg(serde_json::json!({"tx_id": "b", "amount": 2})), None)
         .await
         .unwrap();
     assert_eq!(chain.transactions.len(), 2);
@@ -150,22 +153,25 @@ async fn test_transaction_chain_tracks_order() {
 async fn test_mempool_and_document_cache_ops() {
     let mut mempool = Mempool::new();
     mempool
-        .add_message(msg(serde_json::json!({"from": "a", "to": "b", "amount": 1})))
+        .add_message(msg(serde_json::json!({"from": "a", "to": "b", "amount": 1})), None)
         .await
         .unwrap();
     assert_eq!(mempool.transactions.len(), 1);
     let tx_id = mempool.transactions.keys().next().unwrap().clone();
     mempool
-        .add_message(msg(serde_json::json!({"tx_id": tx_id, "action": "remove"})))
+        .add_message(msg(serde_json::json!({"tx_id": tx_id, "action": "remove"})), None)
         .await
         .unwrap();
     assert!(mempool.transactions.is_empty());
 
     let mut docs = DocumentCache::new();
-    docs.add_message(msg(serde_json::json!({
-        "document_id": "d1",
-        "value": {"title": "hello"}
-    })))
+    docs.add_message(
+        msg(serde_json::json!({
+            "document_id": "d1",
+            "value": {"title": "hello"}
+        })),
+        None,
+    )
     .await
     .unwrap();
     assert_eq!(docs.documents["d1"]["title"], "hello");

--- a/tests/test_memento_pipeline.rs
+++ b/tests/test_memento_pipeline.rs
@@ -1,0 +1,329 @@
+use async_trait::async_trait;
+use chaincraft::shared::{MessageType, SharedMessage, SharedObjectId};
+use chaincraft::shared_object::{ApplicationObject, ApplicationObjectRegistry};
+use chaincraft::{blockchain_helpers, normalize_state_memento, BlockchainObject, StateMemento};
+use serde_json::Value;
+use std::any::Any;
+
+#[derive(Debug, Clone)]
+struct EmitterObject {
+    id: SharedObjectId,
+}
+
+#[async_trait]
+impl ApplicationObject for EmitterObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "EmitterObject"
+    }
+
+    async fn is_valid(&self, _message: &SharedMessage) -> chaincraft::Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_message(
+        &mut self,
+        _message: SharedMessage,
+        _frontier_state: Option<StateMemento>,
+    ) -> chaincraft::Result<Option<StateMemento>> {
+        Ok(Some(normalize_state_memento("digest-a", Some(vec!["digest-a".to_string()]))))
+    }
+
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> chaincraft::Result<String> {
+        Ok("digest-a".to_string())
+    }
+    async fn has_digest(&self, _digest: &str) -> chaincraft::Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> chaincraft::Result<bool> {
+        Ok(true)
+    }
+    async fn add_digest(&mut self, _digest: String) -> chaincraft::Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(
+        &self,
+        _digest: Option<&str>,
+    ) -> chaincraft::Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(
+        &self,
+        _digest: &str,
+    ) -> chaincraft::Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    fn get_state_digests(&self) -> Vec<String> {
+        vec!["digest-a".to_string()]
+    }
+    async fn get_state(&self) -> chaincraft::Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    async fn reset(&mut self) -> chaincraft::Result<()> {
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReceiverObject {
+    id: SharedObjectId,
+    last_frontier: Option<StateMemento>,
+}
+
+#[async_trait]
+impl ApplicationObject for ReceiverObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+
+    fn type_name(&self) -> &'static str {
+        "ReceiverObject"
+    }
+
+    async fn is_valid(&self, _message: &SharedMessage) -> chaincraft::Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_message(
+        &mut self,
+        _message: SharedMessage,
+        frontier_state: Option<StateMemento>,
+    ) -> chaincraft::Result<Option<StateMemento>> {
+        self.last_frontier = frontier_state.clone();
+        Ok(frontier_state)
+    }
+
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> chaincraft::Result<String> {
+        Ok(self
+            .last_frontier
+            .as_ref()
+            .map(|m| m.canonical_digest.clone())
+            .unwrap_or_default())
+    }
+    async fn has_digest(&self, _digest: &str) -> chaincraft::Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> chaincraft::Result<bool> {
+        Ok(true)
+    }
+    async fn add_digest(&mut self, _digest: String) -> chaincraft::Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(
+        &self,
+        _digest: Option<&str>,
+    ) -> chaincraft::Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(
+        &self,
+        _digest: &str,
+    ) -> chaincraft::Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> chaincraft::Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    async fn reset(&mut self) -> chaincraft::Result<()> {
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RejectorObject {
+    id: SharedObjectId,
+}
+
+#[async_trait]
+impl ApplicationObject for RejectorObject {
+    fn id(&self) -> &SharedObjectId {
+        &self.id
+    }
+    fn type_name(&self) -> &'static str {
+        "RejectorObject"
+    }
+    async fn is_valid(&self, _message: &SharedMessage) -> chaincraft::Result<bool> {
+        Ok(false)
+    }
+    async fn add_message(
+        &mut self,
+        _message: SharedMessage,
+        _frontier_state: Option<StateMemento>,
+    ) -> chaincraft::Result<Option<StateMemento>> {
+        Ok(None)
+    }
+    fn is_merkleized(&self) -> bool {
+        false
+    }
+    async fn get_latest_digest(&self) -> chaincraft::Result<String> {
+        Ok(String::new())
+    }
+    async fn has_digest(&self, _digest: &str) -> chaincraft::Result<bool> {
+        Ok(false)
+    }
+    async fn is_valid_digest(&self, _digest: &str) -> chaincraft::Result<bool> {
+        Ok(true)
+    }
+    async fn add_digest(&mut self, _digest: String) -> chaincraft::Result<bool> {
+        Ok(false)
+    }
+    async fn gossip_messages(
+        &self,
+        _digest: Option<&str>,
+    ) -> chaincraft::Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_messages_since_digest(
+        &self,
+        _digest: &str,
+    ) -> chaincraft::Result<Vec<SharedMessage>> {
+        Ok(vec![])
+    }
+    async fn get_state(&self) -> chaincraft::Result<Value> {
+        Ok(serde_json::json!({}))
+    }
+    async fn reset(&mut self) -> chaincraft::Result<()> {
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn ApplicationObject> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+fn msg(data: Value) -> SharedMessage {
+    SharedMessage::new(MessageType::Custom("TEST".to_string()), data)
+}
+
+#[tokio::test]
+async fn test_pipeline_propagates_frontier_memento_between_objects() {
+    let mut registry = ApplicationObjectRegistry::new();
+    registry.register(Box::new(EmitterObject {
+        id: SharedObjectId::new(),
+    }));
+    let receiver_id = registry.register(Box::new(ReceiverObject {
+        id: SharedObjectId::new(),
+        last_frontier: None,
+    }));
+
+    registry
+        .process_message(msg(serde_json::json!({"k":"v"})))
+        .await
+        .unwrap();
+
+    let receiver = registry
+        .objects
+        .get(&receiver_id)
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ReceiverObject>()
+        .unwrap();
+    let frontier = receiver.last_frontier.as_ref().unwrap();
+    assert_eq!(frontier.canonical_digest, "digest-a");
+    assert!(frontier.frontier_digests.iter().any(|d| d == "digest-a"));
+}
+
+#[tokio::test]
+async fn test_pipeline_rejects_message_when_any_object_invalid() {
+    let mut registry = ApplicationObjectRegistry::new();
+    registry.register(Box::new(RejectorObject {
+        id: SharedObjectId::new(),
+    }));
+    registry.register(Box::new(EmitterObject {
+        id: SharedObjectId::new(),
+    }));
+
+    let result = registry
+        .process_message(msg(serde_json::json!({"k":"v"})))
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_blockchain_memento_reorg_metadata_shape() {
+    let mut blockchain = BlockchainObject::with_reward(10);
+    let genesis = blockchain.latest_block().digest.clone();
+    let block1 = blockchain_helpers::create_block_message_with_transactions(
+        1,
+        genesis.clone(),
+        "miner-a".to_string(),
+        vec![],
+        serde_json::json!({"id":"b1"}),
+    );
+    let msg1 = SharedMessage::new(MessageType::Custom("NEW_BLOCK".to_string()), block1);
+    let _ = blockchain.add_message(msg1, None).await.unwrap();
+
+    let tx1 = blockchain_helpers::create_simple_transfer_tx("tx-1", "miner-a", "bob", 2, 1);
+    let block2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        blockchain.latest_block().digest.clone(),
+        "miner-a".to_string(),
+        vec![tx1.clone()],
+        serde_json::json!({"id":"b2"}),
+    );
+    let msg2 = SharedMessage::new(MessageType::Custom("NEW_BLOCK".to_string()), block2);
+    let _ = blockchain.add_message(msg2, None).await.unwrap();
+
+    let c2 = blockchain_helpers::create_block_message_with_transactions(
+        2,
+        blockchain.chain[1].digest.clone(),
+        "miner-c".to_string(),
+        vec![],
+        serde_json::json!({"id":"c2"}),
+    );
+    let c2_msg = SharedMessage::new(MessageType::Custom("NEW_BLOCK".to_string()), c2);
+    let _ = blockchain.add_message(c2_msg, None).await.unwrap();
+
+    let c3 = blockchain_helpers::create_block_message_with_transactions(
+        3,
+        blockchain
+            .get_state_digests()
+            .iter()
+            .find(|d| **d != blockchain.latest_block().digest)
+            .cloned()
+            .unwrap_or_default(),
+        "miner-c".to_string(),
+        vec![],
+        serde_json::json!({"id":"c3"}),
+    );
+    let c3_msg = SharedMessage::new(MessageType::Custom("NEW_BLOCK".to_string()), c3);
+    let memento = blockchain.add_message(c3_msg, None).await.unwrap().unwrap();
+
+    assert_eq!(memento.metadata.get("reorg"), Some(&serde_json::json!(true)));
+    assert!(memento.metadata.contains_key("reorg_from_height"));
+    assert_eq!(memento.metadata.get("reverted_txs"), Some(&serde_json::json!([tx1])));
+    assert_eq!(memento.metadata.get("applied_tx_ids"), Some(&serde_json::json!([])));
+    assert!(memento.metadata.contains_key("chain_length"));
+}

--- a/tests/test_randomness_beacon_network.rs
+++ b/tests/test_randomness_beacon_network.rs
@@ -1,10 +1,14 @@
 //! Multi-node Randomness Beacon tests over real UDP/gossip layer
 
 use chaincraft::{
-    clear_local_registry, examples::randomness_beacon::RandomnessBeaconObject, network::PeerId,
-    shared_object::ApplicationObject, storage::MemoryStorage, ChaincraftNode,
+    clear_local_registry,
+    crypto::ecdsa::ECDSASigner,
+    examples::randomness_beacon::{helpers, RandomnessBeaconObject},
+    network::PeerId,
+    shared_object::ApplicationObject,
+    storage::MemoryStorage,
+    ChaincraftNode,
 };
-use serde_json::json;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
@@ -54,13 +58,15 @@ async fn test_beacon_three_node_network() {
     connect_mesh(&mut nodes).await;
     sleep(Duration::from_secs(2)).await;
 
-    let msg = json!({
-        "type": "beacon_contribution",
-        "round": 1,
-        "contributor_id": "node_0",
-        "share": "share_0",
-        "proof": "proof_0"
-    });
+    let signer = ECDSASigner::new().unwrap();
+    let msg = helpers::create_validator_registration(
+        signer.get_public_key_pem().unwrap(),
+        signer.get_public_key_pem().unwrap(),
+        "vrf_key_0".to_string(),
+        100,
+        &signer,
+    )
+    .unwrap();
     nodes[0].create_shared_message_with_data(msg).await.unwrap();
 
     assert!(wait_for_sync(&nodes, 1, 10).await);
@@ -77,13 +83,15 @@ async fn test_beacon_multi_contribution_propagation() {
     sleep(Duration::from_secs(2)).await;
 
     for (i, node) in nodes.iter_mut().enumerate() {
-        let msg = json!({
-            "type": "beacon_contribution",
-            "round": 1,
-            "contributor_id": format!("node_{}", i),
-            "share": format!("share_{}", i),
-            "proof": format!("proof_{}", i)
-        });
+        let signer = ECDSASigner::new().unwrap();
+        let msg = helpers::create_validator_registration(
+            signer.get_public_key_pem().unwrap(),
+            signer.get_public_key_pem().unwrap(),
+            format!("vrf_key_{i}"),
+            100,
+            &signer,
+        )
+        .unwrap();
         node.create_shared_message_with_data(msg).await.unwrap();
         sleep(Duration::from_millis(100)).await;
     }

--- a/tests/test_shared_object_updates.rs
+++ b/tests/test_shared_object_updates.rs
@@ -360,7 +360,7 @@ async fn test_deduplication() {
         serde_json::json!(existing_hash),
     );
 
-    chain.add_message(dup_msg.clone()).await.unwrap();
+    chain.add_message(dup_msg.clone(), None).await.unwrap();
 
     // Length should not increase
     assert_eq!(

--- a/tests/test_slush.rs
+++ b/tests/test_slush.rs
@@ -48,7 +48,7 @@ async fn test_slush_add_message_adopts_color() {
     let vote_data = create_vote_message("n2", 1, Color::Blue);
     let msg = SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), vote_data);
     assert!(slush.is_valid(&msg).await.unwrap());
-    slush.add_message(msg).await.unwrap();
+    slush.add_message(msg, None).await.unwrap();
 
     assert_eq!(slush.color, Some(Color::Blue));
     assert_eq!(slush.votes().len(), 1);
@@ -59,8 +59,8 @@ async fn test_slush_deduplication() {
     let mut slush = SlushObject::new("n1".into(), 4, 0.5, 8);
     let vote_data = create_vote_message("n2", 1, Color::Red);
     let msg = SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), vote_data);
-    slush.add_message(msg.clone()).await.unwrap();
-    slush.add_message(msg).await.unwrap();
+    slush.add_message(msg.clone(), None).await.unwrap();
+    slush.add_message(msg, None).await.unwrap();
     assert_eq!(slush.votes().len(), 1);
 }
 
@@ -71,11 +71,11 @@ async fn test_slush_count_votes() {
     for i in 0..3 {
         let vote = create_vote_message(&format!("peer-{i}"), 1, Color::Blue);
         let msg = SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), vote);
-        slush.add_message(msg).await.unwrap();
+        slush.add_message(msg, None).await.unwrap();
     }
     let vote = create_vote_message("peer-3", 1, Color::Red);
     let msg = SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), vote);
-    slush.add_message(msg).await.unwrap();
+    slush.add_message(msg, None).await.unwrap();
 
     let (red, blue) = slush.count_votes_for_round(1);
     assert_eq!(red, 1);
@@ -90,7 +90,7 @@ async fn test_slush_process_round_flips() {
     for i in 0..3 {
         let vote = create_vote_message(&format!("peer-{i}"), 1, Color::Blue);
         let msg = SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), vote);
-        slush.add_message(msg).await.unwrap();
+        slush.add_message(msg, None).await.unwrap();
     }
     let flipped = slush.process_round(1);
     assert!(flipped);
@@ -105,11 +105,11 @@ async fn test_slush_process_round_no_flip() {
     let v1 = create_vote_message("peer-0", 1, Color::Blue);
     let v2 = create_vote_message("peer-1", 1, Color::Red);
     slush
-        .add_message(SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), v1))
+        .add_message(SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), v1), None)
         .await
         .unwrap();
     slush
-        .add_message(SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), v2))
+        .add_message(SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), v2), None)
         .await
         .unwrap();
     let flipped = slush.process_round(1);
@@ -134,7 +134,7 @@ async fn test_slush_reset() {
     slush.current_round = 5;
     let vote = create_vote_message("peer-0", 1, Color::Red);
     slush
-        .add_message(SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), vote))
+        .add_message(SharedMessage::new(MessageType::Custom("SLUSH_VOTE".into()), vote), None)
         .await
         .unwrap();
     slush.reset().await.unwrap();

--- a/tests/test_tendermint_network.rs
+++ b/tests/test_tendermint_network.rs
@@ -1,10 +1,14 @@
 //! Multi-node Tendermint consensus tests over real UDP/gossip layer
 
 use chaincraft::{
-    clear_local_registry, examples::tendermint::TendermintObject, network::PeerId,
-    shared_object::ApplicationObject, storage::MemoryStorage, ChaincraftNode,
+    clear_local_registry,
+    crypto::ecdsa::ECDSASigner,
+    examples::tendermint::{helpers, TendermintObject},
+    network::PeerId,
+    shared_object::ApplicationObject,
+    storage::MemoryStorage,
+    ChaincraftNode,
 };
-use serde_json::json;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
@@ -54,7 +58,15 @@ async fn test_tendermint_three_node_network() {
     connect_mesh(&mut nodes).await;
     sleep(Duration::from_secs(2)).await;
 
-    let msg = json!({"type": "tendermint_proposal", "height": 1, "round": 0, "block_hash": "test"});
+    let signer = ECDSASigner::new().unwrap();
+    let msg = helpers::create_proposal_message(
+        1,
+        0,
+        "test".to_string(),
+        signer.get_public_key_pem().unwrap(),
+        &signer,
+    )
+    .unwrap();
     nodes[0].create_shared_message_with_data(msg).await.unwrap();
 
     assert!(wait_for_sync(&nodes, 1, 10).await);
@@ -71,13 +83,15 @@ async fn test_tendermint_multi_message_propagation() {
     sleep(Duration::from_secs(2)).await;
 
     for i in 0..3 {
-        let msg = json!({
-            "type": "tendermint_prevote",
-            "height": 1,
-            "round": 0,
-            "block_hash": "prop1",
-            "validator": format!("validator_{}", i)
-        });
+        let signer = ECDSASigner::new().unwrap();
+        let msg = helpers::create_prevote_message(
+            1,
+            0,
+            Some("prop1".to_string()),
+            format!("validator_{i}"),
+            &signer,
+        )
+        .unwrap();
         nodes[0].create_shared_message_with_data(msg).await.unwrap();
         sleep(Duration::from_millis(100)).await;
     }


### PR DESCRIPTION
This pull request introduces Chaincraft Rust protocol contract v2, updating the core pipeline, protocol interface, and documentation to reflect the new "memento" pipeline semantics. The changes include a breaking version bump to `0.4.0`, a new protocol specification, updates to the `ApplicationObject` trait (notably the `add_message` signature), and new or updated examples to demonstrate v2 features.

**Protocol and API changes:**

* Updated the `ApplicationObject` trait: `add_message` now takes an additional `frontier_state: Option<StateMemento>` parameter and returns `Result<Option<StateMemento>>`, aligning all core object implementations with the new v2 pipeline contract. (`src/core_objects.rs`) [[1]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L333-R339) [[2]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L423-R441) [[3]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L548-R564) [[4]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L578-R591) [[5]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L687-R707) [[6]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L741-R758) [[7]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L842-R866) [[8]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L862-R883) [[9]](diffhunk://#diff-8581d92b5a82c664d4a7cb81d4e1e6ab1b0b8c590634bced5780d7506e8c1d17L981-R1009)
* Added `StateMemento` as a core concept, now passed through the pipeline and emitted by objects for deterministic state transitions. (`src/core_objects.rs`)
* Bumped crate version to `0.4.0` to signal the breaking API change. (`Cargo.toml`)

**Documentation and specification:**

* Replaced the old protocol spec with a new `SPECS.md` describing the v2 pipeline, memento propagation, and updated object/trait interfaces. This includes a protocol author checklist and implementation guidance. (`SPECS.md`)
* Updated the `README.md` to reference version `0.4.0`, document new and updated examples, and summarize the v2 pipeline and its usage. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R198) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R260-R264) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R274-R285)

**Examples:**

* Added a new `blockchain_example.rs` demonstrating a memento-aware blockchain pipeline using the v2 contract. (`examples/blockchain_example.rs`)
* Documented additional v2 examples in the `README.md` for Avalanche-family consensus and ledger workflows. (`README.md`)

These changes collectively upgrade Chaincraft Rust to the new v2 protocol contract, providing deterministic, multi-object pipeline semantics and improved protocol author ergonomics.