### PR TITLE
Fix flaky local discovery tests and macOS GMP linking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,10 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
+# Homebrew GMP (required by optional feature vdf-crypto) lives outside default link paths on Apple Silicon.
+[target.aarch64-apple-darwin]
+rustflags = ["-L", "/opt/homebrew/opt/gmp/lib"]
+
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
 rustflags = ["-C", "link-arg=/LTCG"]

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,12 @@ target/
 
 # Publication checklist
 PUBLICATION_CHECKLIST.md
+
+# Coverage artifacts
+lcov.info
+*.profraw
+*.profdata
+coverage/
+
+# Local persistent node databases created during tests/runs
+node_*.db/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-09
+
+### Fixed
+- Serialize local-discovery tests with an async mutex to avoid flaky races on the shared `LOCAL_NODES` registry
+- Add Homebrew GMP link path for Apple Silicon (`vdf-crypto`)
+- Allow `clippy::double_must_use` false positives from `async_trait` expansion
+- Ignore coverage artifacts and local `node_*.db/` databases
+
+### Changed
+- Bump crate version to 0.4.1
+
 ## [0.3.0] - 2026-04-07
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaincraft"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaincraft"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Chaincraft Contributors"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Add Chaincraft Rust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = "0.4.0"
+chaincraft = "0.4.1"
 ```
 
 ### Basic Example
@@ -195,7 +195,7 @@ Enable features in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chaincraft = { version = "0.4.0", features = ["persistent", "indexing"] }
+chaincraft = { version = "0.4.1", features = ["persistent", "indexing"] }
 ```
 
 ## Development

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(unused_variables)]
+// async_trait expands async fns into Pin<Box<dyn Future>> with a redundant #[must_use].
+#![allow(clippy::double_must_use)]
 
 // Modules
 pub mod consensus;

--- a/tests/test_local_discovery.rs
+++ b/tests/test_local_discovery.rs
@@ -1,13 +1,22 @@
 //! Tests for local discovery (in-process peer registry)
 //!
 //! Mirrors Python's test_local_discovery behavior.
+//!
+//! These tests share the process-global LOCAL_NODES registry, so they must not
+//! run concurrently with each other.
 
 use chaincraft::{
     clear_local_registry, network::PeerId, shared_object::SimpleSharedNumber,
     storage::MemoryStorage, ApplicationObject, ChaincraftNode,
 };
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
+
+fn local_discovery_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 async fn create_network(num_nodes: usize) -> Vec<ChaincraftNode> {
     clear_local_registry();
@@ -45,10 +54,12 @@ async fn wait_for_peers(nodes: &[ChaincraftNode], min_peers: usize, timeout_secs
 
 #[tokio::test]
 async fn test_local_discovery_three_nodes() {
+    let _guard = local_discovery_lock().lock().await;
+
     let mut nodes = create_network(3).await;
     assert!(
-        wait_for_peers(&nodes, 2, 5).await,
-        "Local discovery should discover peers within 5s"
+        wait_for_peers(&nodes, 2, 10).await,
+        "Local discovery should discover peers within 10s"
     );
 
     let mut peer_counts = Vec::new();
@@ -75,14 +86,17 @@ async fn test_local_discovery_three_nodes() {
     for mut node in nodes {
         node.close().await.unwrap();
     }
+    clear_local_registry();
 }
 
 #[tokio::test]
 async fn test_local_discovery_five_nodes() {
+    let _guard = local_discovery_lock().lock().await;
+
     let nodes = create_network(5).await;
     assert!(
-        wait_for_peers(&nodes, 4, 8).await,
-        "Local discovery should discover peers within 8s"
+        wait_for_peers(&nodes, 4, 15).await,
+        "Local discovery should discover peers within 15s"
     );
 
     let mut peer_counts = Vec::new();
@@ -97,4 +111,5 @@ async fn test_local_discovery_five_nodes() {
     for mut node in nodes {
         node.close().await.unwrap();
     }
+    clear_local_registry();
 }


### PR DESCRIPTION
## Summary
- Serialize local-discovery tests that race on the shared `LOCAL_NODES` registry
- Add Apple Silicon Homebrew GMP link path for `vdf-crypto`
- Ignore coverage and local `node_*.db/` artifacts
## Test plan
- [x] `cargo test --all-features`
- [x] `cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info`